### PR TITLE
feat: adding a method for aborting the current active webauthn operation

### DIFF
--- a/webforj-addons-services/webforj-webauthn/src/main/java/com/webforj/addons/services/webauthn/RelyingParty.java
+++ b/webforj-addons-services/webforj-webauthn/src/main/java/com/webforj/addons/services/webauthn/RelyingParty.java
@@ -110,6 +110,16 @@ public class RelyingParty {
   }
 
   /**
+   * Cancels an active WebAuthn operation, it can be authentication or registration, the last
+   * operation reference will always be stored and can have only one active operation at a time.
+   * <p>
+   * Therefore, canceling a ceremony aborts the last operation which is also the only active one.
+   */
+  public void cancelCeremony() {
+    this.anyElement.getElement().executeJs("window.dwcWebAuthn.cancelCeremony()");
+  }
+
+  /**
    * Checks whether the current browser environment supports the Web Authentication API (WebAuthn).
    *
    * @return True if WebAuthn is supported in the current environment, false otherwise.


### PR DESCRIPTION
This PR introduces an abort controller for WebAuthn operations, enhancing the flexibility and control available to developers when handling registration and authentication processes. Previously, once initiated, WebAuthn operations could not be canceled or aborted, limiting the ability to manage user interactions effectively. With the addition of the abortion method, developers can now abort ongoing WebAuthn operations, providing a more robust and user-friendly API.