### PR TITLE
deps: update webforj modules and the project sync with the version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.webforj.addons</groupId>
   <artifactId>webforj-addons</artifactId>
-  <version>24.02-SNAPSHOT</version>
+  <version>24.10-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>webforj-addons</name>
@@ -25,7 +25,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <webforj.version>24.02</webforj.version>
+    <webforj.version>24.10</webforj.version>
   </properties>
 
   <issueManagement>

--- a/webforj-addons-components/pom.xml
+++ b/webforj-addons-components/pom.xml
@@ -7,11 +7,13 @@
   <parent>
     <groupId>com.webforj.addons</groupId>
     <artifactId>webforj-addons</artifactId>
-    <version>24.02-SNAPSHOT</version>
+    <version>24.10-SNAPSHOT</version>
   </parent>
-  <packaging>pom</packaging>
 
   <artifactId>webforj-addons-components</artifactId>
+  <version>24.10-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
   <name>${project.artifactId}</name>
   <description>
     addons for webforJ enhances the user interface of the main webforJ framework with a diverse
@@ -48,7 +50,7 @@
     <dependency>
       <groupId>com.webforj</groupId>
       <artifactId>webforj-foundation</artifactId>
-      <version>24.02</version>
+      <version>${webforj.version}</version>
     </dependency>
   </dependencies>
 

--- a/webforj-addons-components/webforj-multi-select-combo/pom.xml
+++ b/webforj-addons-components/webforj-multi-select-combo/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>com.webforj.addons</groupId>
     <artifactId>webforj-addons-components</artifactId>
-    <version>24.02-SNAPSHOT</version>
+    <version>24.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>webforj-multi-select-combo</artifactId>
-  <version>24.02-SNAPSHOT</version>
+  <version>${project.parent.version}</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/webforj-addons-components/webforj-properties-panel/pom.xml
+++ b/webforj-addons-components/webforj-properties-panel/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>com.webforj.addons</groupId>
     <artifactId>webforj-addons-components</artifactId>
-    <version>24.02-SNAPSHOT</version>
+    <version>24.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>webforj-properties-panel</artifactId>
-  <version>24.02-SNAPSHOT</version>
+  <version>${project.parent.version}</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/webforj-addons-components/webforj-side-menu/pom.xml
+++ b/webforj-addons-components/webforj-side-menu/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>com.webforj.addons</groupId>
     <artifactId>webforj-addons-components</artifactId>
-    <version>24.02-SNAPSHOT</version>
+    <version>24.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>webforj-side-menu</artifactId>
-  <version>24.02-SNAPSHOT</version>
+  <version>${project.parent.version}</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/webforj-addons-components/webforj-suggestion-edit/pom.xml
+++ b/webforj-addons-components/webforj-suggestion-edit/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>com.webforj.addons</groupId>
     <artifactId>webforj-addons-components</artifactId>
-    <version>24.02-SNAPSHOT</version>
+    <version>24.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>webforj-suggestion-edit</artifactId>
-  <version>24.02-SNAPSHOT</version>
+  <version>${project.parent.version}</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/webforj-addons-services/pom.xml
+++ b/webforj-addons-services/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>com.webforj.addons</groupId>
     <artifactId>webforj-addons</artifactId>
-    <version>24.02-SNAPSHOT</version>
+    <version>24.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>webforj-addons-services</artifactId>
-  <version>24.02-SNAPSHOT</version>
+  <version>24.10-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>${project.artifactId}</name>
@@ -20,16 +20,16 @@
     authorization, and other core services that support the main webforJ framework.
   </description>
 
-  <modules>
-    <module>webforj-webauthn</module>
-    <module>webforj-simple-router</module>
-  </modules>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
   </properties>
+
+  <modules>
+    <module>webforj-webauthn</module>
+    <module>webforj-simple-router</module>
+  </modules>
 
   <pluginRepositories>
     <pluginRepository>

--- a/webforj-addons-services/webforj-simple-router/pom.xml
+++ b/webforj-addons-services/webforj-simple-router/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>com.webforj.addons</groupId>
     <artifactId>webforj-addons-services</artifactId>
-    <version>24.02-SNAPSHOT</version>
+    <version>24.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>webforj-simple-router</artifactId>
-  <version>24.02-SNAPSHOT</version>
+  <version>${project.parent.version}</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/webforj-addons-services/webforj-webauthn/pom.xml
+++ b/webforj-addons-services/webforj-webauthn/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>com.webforj.addons</groupId>
     <artifactId>webforj-addons-services</artifactId>
-    <version>24.02-SNAPSHOT</version>
+    <version>24.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>webforj-webauthn</artifactId>
-  <version>24.02-SNAPSHOT</version>
+  <version>${project.parent.version}</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.webforj</groupId>
       <artifactId>webforj-html-elements</artifactId>
-      <version>24.02</version>
+      <version>${webforj.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### Summary
This PR aims to upgrade webforJ dependency and all its modules from webforj@24.02 to webforj@24.10. There were no breaking changes to align with. The PR also replaces the hardwritten versions of individual modules with a variable that references the root project version for easier and safer modification.


> [!NOTE]
> The version of the project has also upgraded from 24.02-SNAPSHOT to 24.10-SNAPSHOT to synchronize with webforj version.