### PR TITLE
feat: adding bump version workflow to the repo

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,59 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version number"
+        required: true
+      createTag:
+        description: "Create a new release"
+        type: boolean
+        required: false
+        default: false
+      prerelease:
+        description: "Is pre-release?"
+        type: boolean
+        required: false
+        default: false
+      draft:
+        description: "Is draft?"
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  bumpVersion:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xmlstarlet
+        run: sudo apt install -y xmlstarlet
+
+      - name: Install Maven
+        run: sudo apt install maven
+
+      - name: Bump version in POM files
+        run: mvn versions:set -DnewVersion=${{ github.event.inputs.version }} -q
+
+      - name: Commit & Push changes
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -a -m "build: bump version to ${{ github.event.inputs.version }}"
+          git push origin HEAD:${{ github.ref }}
+
+      - name: Create Release
+        if: ${{ github.event.inputs.createTag == 'true' }}
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          generateReleaseNotes: true
+          tag: ${{ github.event.inputs.version }}
+          name: Release v${{ github.event.inputs.version }}
+          draft: ${{ github.event.inputs.draft }}
+          prerelease: ${{ github.event.inputs.prerelease }}
+          makeLatest: ${{ github.event.inputs.prerelease == 'false' }}


### PR DESCRIPTION
### Summary
This PR introduces a new GitHub Actions workflow that automates updating the version number across the project. The workflow simplifies version management, ensuring consistency and reducing the risk of manual errors during version bumps.

#### **Key Features**
- **Manual Trigger via `workflow_dispatch`:**
  - The workflow can be manually triggered with inputs for the new version number, and optional flags for creating a tag, marking the release as a draft, or indicating a pre-release.

- **Version Bumping in POM Files:**
  - The workflow automatically updates the version number in all relevant POM files using Maven’s `versions:set` command, ensuring that all references to the version number are consistent.

- **Commit and Push Changes:**
  - After updating the version number, the workflow commits the changes and pushes them to the current branch, keeping the repository up to date.

- **Conditional Release Creation:**
  - If the `createTag` input is set to `true`, the workflow will create a new release with the specified version, including options for draft and pre-release settings.