### PR TITLE
fix: unexpected uppercase value set to client component

### DIFF
--- a/webforj-addons-components/webforj-side-menu/src/main/java/com/webforj/addons/components/sidemenu/SideMenu.java
+++ b/webforj-addons-components/webforj-side-menu/src/main/java/com/webforj/addons/components/sidemenu/SideMenu.java
@@ -303,7 +303,7 @@ public class SideMenu extends ElementComposite
 			if (!concatenatedSections.isEmpty()) {
 				concatenatedSections.append(", ");
 			}
-			concatenatedSections.append(section.name());
+			concatenatedSections.append(section.name().toLowerCase());
 		}
 
 		super.set(sectionsProp, concatenatedSections.toString());


### PR DESCRIPTION
### Summary
This PR aims to fix the issue with the `SideMenu` component section properties that were not showing the sections when set, it's because the client component was expecting the values of `items` and `favorites` as names of sections to be lowercase letter and it was not set as lower case letter from `SideMenu` Java component.