### PR TITLE
feat(properties-panel): Add description property to BaseSchema

### DIFF
--- a/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/BaseSchema.java
+++ b/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/BaseSchema.java
@@ -22,6 +22,11 @@ public abstract class BaseSchema<T extends BaseSchema<T>> {
 	 */
 	private String label;
 
+  /**
+   * An optional description for the property, which can be used for tooltips or help text.
+   */
+  private String description;
+
 	/**
 	 * The data type of the property, the possible values are:
 	 * <ol>
@@ -87,6 +92,26 @@ public abstract class BaseSchema<T extends BaseSchema<T>> {
 		this.label = label;
 		return this.getThis();
 	}
+
+  /**
+   * Retrieves the description for the property.
+   *
+   * @return The description of the property.
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Sets the description for the property.
+   *
+   * @param description The description to set for the property.
+   * @return The current instance for chaining.
+   */
+  public T setDescription(String description) {
+    this.description = description;
+    return this.getThis();
+  }
 
 	/**
 	 * Retrieves the data type of the property.


### PR DESCRIPTION
### Description
This PR updates the `PropertiesPanel` component's schema definition to align with recent changes in the client-side component. Specifically, it introduces a new optional `description` property to the `BaseSchema` class. The client component now utilizes this `description` property to display a tooltip next to the property label, providing users with additional context or help text for each property.