### PR TITLE
feat: add variant property to PropertiesPanel schemas

### DIFF
--- a/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/BooleanSchema.java
+++ b/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/BooleanSchema.java
@@ -1,10 +1,12 @@
 package com.webforj.addons.components.propertiespanel.schema;
 
 import com.google.gson.Gson;
+import com.webforj.addons.components.propertiespanel.schema.variants.BooleanVariant;
+import java.util.Objects;
 
 /**
- * Represents a schema for a boolean property in a properties panel. Extends the BaseSchema class
- * and adds additional attributes specific to boolean properties.
+ * Represents a schema for a boolean property in a properties panel. Extends the {@link BaseSchema}
+ * class and adds additional attributes specific to boolean properties.
  *
  * @author ElyasSalar
  * @since 1.00
@@ -14,9 +16,42 @@ public class BooleanSchema extends BaseSchema<BooleanSchema> {
   /** The default value for the boolean property. */
   private Boolean defaultValue;
 
-  /** Constructs a new {@code BooleanSchema}. */
+  /** The UI variant for the boolean property. */
+  private BooleanVariant variant;
+
+  /**
+   * Constructs a new {@code BooleanSchema} with a name and label, defaulting the variant to {@link
+   * BooleanVariant#CHECKBOX}.
+   *
+   * @param name The unique name (key) for the property.
+   * @param label The human-readable label for the property.
+   * @throws NullPointerException if name or label is null.
+   */
   public BooleanSchema(String name, String label) {
-    this.setType("boolean").setLabel(label).setName(name);
+    Objects.requireNonNull(name, "name cannot be null");
+    Objects.requireNonNull(label, "label cannot be null");
+    this.setType("boolean");
+    this.setLabel(label);
+    this.setName(name);
+    this.variant = BooleanVariant.CHECKBOX;
+  }
+
+  /**
+   * Constructs a new {@code BooleanSchema} with a name, label, and a specific variant.
+   *
+   * @param name The unique name (key) for the property.
+   * @param label The human-readable label for the property.
+   * @param variant The desired UI variant (currently only {@link BooleanVariant#CHECKBOX}).
+   * @throws NullPointerException if name, label, or variant is null.
+   */
+  public BooleanSchema(String name, String label, BooleanVariant variant) {
+    Objects.requireNonNull(name, "name cannot be null");
+    Objects.requireNonNull(label, "label cannot be null");
+    Objects.requireNonNull(variant, "variant cannot be null");
+    this.setType("boolean");
+    this.setLabel(label);
+    this.setName(name);
+    this.variant = variant;
   }
 
   /**
@@ -41,9 +76,9 @@ public class BooleanSchema extends BaseSchema<BooleanSchema> {
   }
 
   /**
-   * Allows for chaining {@code BooleanScheme} to the {@link BaseSchema} methods.
+   * Returns the specific type instance for chaining {@link BaseSchema} methods.
    *
-   * @return The current instance of this class
+   * @return The current instance of this class.
    */
   @Override
   protected BooleanSchema getThis() {
@@ -63,9 +98,32 @@ public class BooleanSchema extends BaseSchema<BooleanSchema> {
    * Sets the default value for the boolean property.
    *
    * @param defaultValue The default value to set for the boolean property.
+   * @return This {@code BooleanSchema} instance for method chaining.
    */
   public BooleanSchema setDefaultValue(Boolean defaultValue) {
     this.defaultValue = defaultValue;
+    return this;
+  }
+
+  /**
+   * Retrieves the UI variant for the boolean property.
+   *
+   * @return The {@link BooleanVariant} indicating how the property should be displayed.
+   */
+  public BooleanVariant getVariant() {
+    return variant;
+  }
+
+  /**
+   * Sets the UI variant for the boolean property.
+   *
+   * @param variant The {@link BooleanVariant} to set. Cannot be null.
+   * @return This {@code BooleanSchema} instance for method chaining.
+   * @throws NullPointerException if variant is null.
+   */
+  public BooleanSchema setVariant(BooleanVariant variant) {
+    Objects.requireNonNull(variant, "variant cannot be null");
+    this.variant = variant;
     return this;
   }
 }

--- a/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/EnumSchema.java
+++ b/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/EnumSchema.java
@@ -1,12 +1,14 @@
 package com.webforj.addons.components.propertiespanel.schema;
 
 import com.google.gson.Gson;
+import com.webforj.addons.components.propertiespanel.schema.variants.EnumVariant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
- * Represents a schema for an enum property in a properties panel. Extends the BaseSchema class and
- * adds additional attributes specific to enum properties.
+ * Represents a schema for an enum property in a properties panel. Extends the {@link BaseSchema}
+ * class and adds additional attributes specific to enum properties.
  *
  * @author ElyasSalar
  * @since 1.00
@@ -19,9 +21,42 @@ public class EnumSchema extends BaseSchema<EnumSchema> {
   /** The list of options available for the enum property. */
   private List<EnumOption> options = new ArrayList<>();
 
-  /** Constructs a new {@code EnumSchema}. */
+  /** The UI variant for the enum property. */
+  private EnumVariant variant;
+
+  /**
+   * Constructs a new {@code EnumSchema} with a name and label, defaulting the variant to {@link
+   * EnumVariant#LISTBOX}.
+   *
+   * @param name The unique name (key) for the property.
+   * @param label The human-readable label for the property.
+   * @throws NullPointerException if name or label is null.
+   */
   public EnumSchema(String name, String label) {
-    this.setType("enum").setName(name).setLabel(label);
+    Objects.requireNonNull(name, "name cannot be null");
+    Objects.requireNonNull(label, "label cannot be null");
+    this.setType("enum");
+    this.setName(name);
+    this.setLabel(label);
+    this.variant = EnumVariant.LISTBOX;
+  }
+
+  /**
+   * Constructs a new {@code EnumSchema} with a name, label, and a specific variant.
+   *
+   * @param name The unique name (key) for the property.
+   * @param label The human-readable label for the property.
+   * @param variant The desired UI variant (currently only {@link EnumVariant#LISTBOX}).
+   * @throws NullPointerException if name, label, or variant is null.
+   */
+  public EnumSchema(String name, String label, EnumVariant variant) {
+    Objects.requireNonNull(name, "name cannot be null");
+    Objects.requireNonNull(label, "label cannot be null");
+    Objects.requireNonNull(variant, "variant cannot be null");
+    this.setType("enum");
+    this.setName(name);
+    this.setLabel(label);
+    this.variant = variant;
   }
 
   /**
@@ -46,9 +81,9 @@ public class EnumSchema extends BaseSchema<EnumSchema> {
   }
 
   /**
-   * Allows for chaining {@code EnumSchema} to the {@link BaseSchema} methods.
+   * Returns the specific type instance for chaining {@link BaseSchema} methods.
    *
-   * @return The current instance of this class
+   * @return The current instance of this class.
    */
   @Override
   protected EnumSchema getThis() {
@@ -68,9 +103,11 @@ public class EnumSchema extends BaseSchema<EnumSchema> {
    * Sets the default value for the enum property.
    *
    * @param defaultValue The default value to set for the enum property.
+   * @return This {@code EnumSchema} instance for method chaining.
    */
-  public void setDefaultValue(String defaultValue) {
+  public EnumSchema setDefaultValue(String defaultValue) {
     this.defaultValue = defaultValue;
+    return this;
   }
 
   /**
@@ -86,9 +123,32 @@ public class EnumSchema extends BaseSchema<EnumSchema> {
    * Sets the list of options available for the enum property.
    *
    * @param options The list of options to set for the enum property.
+   * @return This {@code EnumSchema} instance for method chaining.
    */
   public EnumSchema setOptions(List<EnumOption> options) {
-    this.options = options;
+    this.options = options == null ? new ArrayList<>() : options;
+    return this;
+  }
+
+  /**
+   * Retrieves the UI variant for the enum property.
+   *
+   * @return The {@link EnumVariant} indicating how the property should be displayed.
+   */
+  public EnumVariant getVariant() {
+    return variant;
+  }
+
+  /**
+   * Sets the UI variant for the enum property.
+   *
+   * @param variant The {@link EnumVariant} to set. Cannot be null.
+   * @return This {@code EnumSchema} instance for method chaining.
+   * @throws NullPointerException if variant is null.
+   */
+  public EnumSchema setVariant(EnumVariant variant) {
+    Objects.requireNonNull(variant, "variant cannot be null");
+    this.variant = variant;
     return this;
   }
 }

--- a/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/NumberSchema.java
+++ b/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/NumberSchema.java
@@ -1,10 +1,12 @@
 package com.webforj.addons.components.propertiespanel.schema;
 
 import com.google.gson.Gson;
+import com.webforj.addons.components.propertiespanel.schema.variants.NumberVariant;
+import java.util.Objects;
 
 /**
- * Represents a schema for a number property in a properties panel. Extends the BaseSchema class and
- * adds additional attributes specific to number properties.
+ * Represents a schema for a number property in a properties panel. Extends the {@link BaseSchema}
+ * class and adds additional attributes specific to number properties.
  *
  * @author ElyasSalar
  * @since 1.00
@@ -17,13 +19,46 @@ public class NumberSchema extends BaseSchema<NumberSchema> {
   /** The validation rules for the number property. */
   private NumberValidation validate;
 
-  /** Constructs a new {@code NumberSchema}. */
+  /** The UI variant for the number property. */
+  private NumberVariant variant;
+
+  /**
+   * Constructs a new {@code NumberSchema} with a name and label, defaulting the variant to {@link
+   * NumberVariant#NUMBER}.
+   *
+   * @param name The unique name (key) for the property.
+   * @param label The human-readable label for the property.
+   * @throws NullPointerException if name or label is null.
+   */
   public NumberSchema(String name, String label) {
-    this.setType("number").setLabel(label).setName(name);
+    Objects.requireNonNull(name, "name cannot be null");
+    Objects.requireNonNull(label, "label cannot be null");
+    this.setType("number");
+    this.setLabel(label);
+    this.setName(name);
+    this.variant = NumberVariant.NUMBER;
   }
 
   /**
-   * Deserializes a JSON string into a NumberSchema object using Gson.
+   * Constructs a new {@code NumberSchema} with a name, label, and a specific variant.
+   *
+   * @param name The unique name (key) for the property.
+   * @param label The human-readable label for the property.
+   * @param variant The desired UI variant (currently only {@link NumberVariant#NUMBER}).
+   * @throws NullPointerException if name, label, or variant is null.
+   */
+  public NumberSchema(String name, String label, NumberVariant variant) {
+    Objects.requireNonNull(name, "name cannot be null");
+    Objects.requireNonNull(label, "label cannot be null");
+    Objects.requireNonNull(variant, "variant cannot be null");
+    this.setType("number");
+    this.setLabel(label);
+    this.setName(name);
+    this.variant = variant;
+  }
+
+  /**
+   * Deserializes a JSON string into a {@code NumberSchema} object using Gson.
    *
    * @param json The JSON string to deserialize.
    * @return A NumberSchema object deserialized from the JSON string.
@@ -34,7 +69,7 @@ public class NumberSchema extends BaseSchema<NumberSchema> {
   }
 
   /**
-   * Serializes the NumberSchema object into a JSON string using Gson.
+   * Serializes the {@code NumberSchema} object into a JSON string using Gson.
    *
    * @return A JSON string representing the NumberSchema object.
    */
@@ -44,9 +79,9 @@ public class NumberSchema extends BaseSchema<NumberSchema> {
   }
 
   /**
-   * Allows for chaining {@code NumberSchema} to the {@link BaseSchema} methods.
+   * Returns the specific type instance for chaining {@link BaseSchema} methods.
    *
-   * @return The current instance of this class
+   * @return The current instance of this class.
    */
   @Override
   protected NumberSchema getThis() {
@@ -66,6 +101,7 @@ public class NumberSchema extends BaseSchema<NumberSchema> {
    * Sets the default value for the number property.
    *
    * @param defaultValue The default value to set for the number property.
+   * @return This {@code NumberSchema} instance for method chaining.
    */
   public NumberSchema setDefaultValue(Double defaultValue) {
     this.defaultValue = defaultValue;
@@ -85,9 +121,32 @@ public class NumberSchema extends BaseSchema<NumberSchema> {
    * Sets the validation rules for the number property.
    *
    * @param validate The validation rules to set for the number property.
+   * @return This {@code NumberSchema} instance for method chaining.
    */
   public NumberSchema setValidate(NumberValidation validate) {
     this.validate = validate;
+    return this;
+  }
+
+  /**
+   * Retrieves the UI variant for the number property.
+   *
+   * @return The {@link NumberVariant} indicating how the property should be displayed.
+   */
+  public NumberVariant getVariant() {
+    return variant;
+  }
+
+  /**
+   * Sets the UI variant for the number property.
+   *
+   * @param variant The {@link NumberVariant} to set. Cannot be null.
+   * @return This {@code NumberSchema} instance for method chaining.
+   * @throws NullPointerException if variant is null.
+   */
+  public NumberSchema setVariant(NumberVariant variant) {
+    Objects.requireNonNull(variant, "variant cannot be null");
+    this.variant = variant;
     return this;
   }
 }

--- a/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/StringSchema.java
+++ b/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/StringSchema.java
@@ -1,10 +1,12 @@
 package com.webforj.addons.components.propertiespanel.schema;
 
 import com.google.gson.Gson;
+import com.webforj.addons.components.propertiespanel.schema.variants.StringVariant;
+import java.util.Objects;
 
 /**
- * Represents a schema for a string property in a properties panel. Extends the BaseSchema class and
- * adds additional attributes specific to string properties.
+ * Represents a schema for a string property in a properties panel. Extends the {@link BaseSchema}
+ * class and adds additional attributes specific to string properties.
  *
  * @author ElyasSalar
  * @since 1.00
@@ -14,11 +16,42 @@ public class StringSchema extends BaseSchema<StringSchema> {
   /** The default value for the string property. */
   private String defaultValue;
 
-  /** Constructs a new {@code StringSchema}. */
+  /** The UI variant for the string property (e.g., text field or text area). */
+  private StringVariant variant;
+
+  /**
+   * Constructs a new {@code StringSchema} with a name and label, defaulting the variant to {@link
+   * StringVariant#TEXT}.
+   *
+   * @param name The unique name (key) for the property.
+   * @param label The human-readable label for the property.
+   * @throws NullPointerException if any of the parameters are null.
+   */
   public StringSchema(String name, String label) {
+    Objects.requireNonNull(name, "name cannot be null");
+    Objects.requireNonNull(label, "label cannot be null");
+    this.variant = StringVariant.TEXT;
     this.setType("string");
     this.setLabel(label);
     this.setName(name);
+  }
+
+  /**
+   * Constructs a new {@code StringSchema} with a name, label, and a specific variant.
+   *
+   * @param name The unique name (key) for the property.
+   * @param label The human-readable label for the property.
+   * @param variant The desired UI variant (e.g., {@link StringVariant#TEXTAREA}).
+   * @throws NullPointerException if any of the parameters are null.
+   */
+  public StringSchema(String name, String label, StringVariant variant) {
+    Objects.requireNonNull(name, "name cannot be null");
+    Objects.requireNonNull(label, "label cannot be null");
+    Objects.requireNonNull(variant, "variant cannot be null");
+    this.setType("string");
+    this.setLabel(label);
+    this.setName(name);
+    this.variant = variant;
   }
 
   /**
@@ -43,9 +76,9 @@ public class StringSchema extends BaseSchema<StringSchema> {
   }
 
   /**
-   * Allows for chaining {@code StringSchema} to the {@link BaseSchema} methods.
+   * Returns the specific type instance for chaining {@link BaseSchema} methods.
    *
-   * @return The current instance of this class
+   * @return The current instance of this class.
    */
   @Override
   protected StringSchema getThis() {
@@ -65,9 +98,33 @@ public class StringSchema extends BaseSchema<StringSchema> {
    * Sets the default value for the string property.
    *
    * @param defaultValue The default value to set for the string property.
+   * @return This {@code StringSchema} instance for method chaining.
    */
   public StringSchema setDefaultValue(String defaultValue) {
     this.defaultValue = defaultValue;
+    return this;
+  }
+
+  /**
+   * Retrieves the UI variant for the string property.
+   *
+   * @return The {@link StringVariant} indicating how the property should be displayed (e.g., TEXT
+   *     or TEXTAREA).
+   */
+  public StringVariant getVariant() {
+    return variant;
+  }
+
+  /**
+   * Sets the UI variant for the string property.
+   *
+   * @param variant The {@link StringVariant} to set (e.g., {@link StringVariant#TEXTAREA}). If
+   *     null, defaults to {@link StringVariant#TEXT}.
+   * @return This {@code StringSchema} instance for method chaining.
+   */
+  public StringSchema setVariant(StringVariant variant) {
+    Objects.requireNonNull(variant, "variant cannot be null");
+    this.variant = variant;
     return this;
   }
 }

--- a/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/variants/BooleanVariant.java
+++ b/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/variants/BooleanVariant.java
@@ -1,0 +1,48 @@
+package com.webforj.addons.components.propertiespanel.schema.variants;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Defines the possible UI variants for a boolean property in the Properties Panel.
+ *
+ * @author ElyasSalar
+ * @since 24.22
+ */
+public enum BooleanVariant {
+
+  /** Represents a standard checkbox input field. */
+  @SerializedName("checkbox")
+  CHECKBOX("checkbox");
+
+  private final String value;
+
+  BooleanVariant(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Gets the string value of the variant.
+   *
+   * @return The string value corresponding to the enum constant.
+   */
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Finds the BooleanVariant enum constant corresponding to the given string value.
+   *
+   * @param value The string value to match (case-insensitive).
+   * @return The corresponding BooleanVariant, or null if no match is found.
+   */
+  public static BooleanVariant fromString(String value) {
+    if (value != null) {
+      for (BooleanVariant variant : BooleanVariant.values()) {
+        if (value.equalsIgnoreCase(variant.value)) {
+          return variant;
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/variants/EnumVariant.java
+++ b/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/variants/EnumVariant.java
@@ -1,0 +1,48 @@
+package com.webforj.addons.components.propertiespanel.schema.variants;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Defines the possible UI variants for an enum property in the Properties Panel.
+ *
+ * @author ElyasSalar
+ * @since 24.22
+ */
+public enum EnumVariant {
+
+  /** Represents a choicebox/listbox input field. */
+  @SerializedName("listbox")
+  LISTBOX("listbox");
+
+  private final String value;
+
+  EnumVariant(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Gets the string value of the variant.
+   *
+   * @return The string value corresponding to the enum constant.
+   */
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Finds the EnumVariant enum constant corresponding to the given string value.
+   *
+   * @param value The string value to match (case-insensitive).
+   * @return The corresponding EnumVariant, or null if no match is found.
+   */
+  public static EnumVariant fromString(String value) {
+    if (value != null) {
+      for (EnumVariant variant : EnumVariant.values()) {
+        if (value.equalsIgnoreCase(variant.value)) {
+          return variant;
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/variants/NumberVariant.java
+++ b/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/variants/NumberVariant.java
@@ -1,0 +1,48 @@
+package com.webforj.addons.components.propertiespanel.schema.variants;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Defines the possible UI variants for a number property in the Properties Panel.
+ *
+ * @author ElyasSalar
+ * @since 24.22
+ */
+public enum NumberVariant {
+
+  /** Represents a standard number input field. */
+  @SerializedName("number")
+  NUMBER("number");
+
+  private final String value;
+
+  NumberVariant(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Gets the string value of the variant.
+   *
+   * @return The string value corresponding to the enum constant.
+   */
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Finds the NumberVariant enum constant corresponding to the given string value.
+   *
+   * @param value The string value to match (case-insensitive).
+   * @return The corresponding NumberVariant, or null if no match is found.
+   */
+  public static NumberVariant fromString(String value) {
+    if (value != null) {
+      for (NumberVariant variant : NumberVariant.values()) {
+        if (value.equalsIgnoreCase(variant.value)) {
+          return variant;
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/variants/StringVariant.java
+++ b/webforj-addons-components/webforj-properties-panel/src/main/java/com/webforj/addons/components/propertiespanel/schema/variants/StringVariant.java
@@ -1,0 +1,52 @@
+package com.webforj.addons.components.propertiespanel.schema.variants;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Defines the possible UI variants for a string property in the Properties Panel.
+ *
+ * @author ElyasSalar
+ * @since 24.22
+ */
+public enum StringVariant {
+
+  /** Represents a single-line text input field. */
+  @SerializedName("text")
+  TEXT("text"),
+
+  /** Represents a multi-line text area input field. */
+  @SerializedName("textarea")
+  TEXTAREA("textarea");
+
+  private final String value;
+
+  StringVariant(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Gets the string value of the variant.
+   *
+   * @return The string value corresponding to the enum constant.
+   */
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Finds the StringVariant enum constant corresponding to the given string value.
+   *
+   * @param value The string value to match (case-insensitive).
+   * @return The corresponding StringVariant, or null if no match is found.
+   */
+  public static StringVariant fromString(String value) {
+    if (value != null) {
+      for (StringVariant variant : StringVariant.values()) {
+        if (value.equalsIgnoreCase(variant.value)) {
+          return variant;
+        }
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
### Description
This PR introduces the `variant` property to the schema definitions (`StringSchema`, `NumberSchema`, `BooleanSchema`, `EnumSchema`) for the `webforj-properties-panel` component. This aligns the schema structure with recent changes made to the corresponding `dwc-properties-panel` client component, which now supports different UI variants for the same data type (e.g., 'text' vs 'textarea' for string properties).

#### Motivation
To enable developers using the Java `PropertiesPanel` component to specify the desired UI variant for properties (like using a textarea instead of a simple text field for a string), matching the functionality recently added to the frontend Stencil component.
