### PR TITLE
feat: Add GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug Report
+description: Create a report to help us improve webforj-addons
+title: "[Bug]: "
+labels: ["type: bug", "status: needs triage"]
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please provide as much detail as possible. Before submitting, please search for similar bug reports in the issues section to avoid duplicates.
+  - type: input
+    id: addon-affected
+    attributes:
+      label: Addon Affected
+      description: Which webforj-addon component or service is affected? (e.g., webforj-side-menu, webforj-webauthn)
+      placeholder: "e.g., webforj-side-menu"
+    validations:
+      required: true
+  - type: input
+    id: addon-version
+    attributes:
+      label: Addon Version
+      description: What version of the addon are you using?
+      placeholder: "e.g., 24.22"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+      placeholder: "E.g., Clicking on a button in the sidebar does not load the associated page component."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Please provide detailed steps to reproduce the bug.
+      placeholder: "E.g., Start the application, open the sidebar, click on the 'Settings' button, and observe that no page is loaded."
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Please provide a clear and concise description of what you expected to happen.
+      placeholder: "E.g., Clicking on the 'Settings' button should load the settings page component in the main view."
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Please provide relevant environment details.
+        - OS: [e.g. Ubuntu 22.04, Windows 11]
+        - Java Version: [e.g. OpenJDK 17]
+        - webforj Version: [e.g. 25.00-SNAPSHOT]
+        - Browser (if applicable): [e.g. Chrome 110, Firefox 108]
+      placeholder: |
+        - OS:
+        - Java Version:
+        - webforj Version:
+        - Browser:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: webforj Core Issues
+    url: https://github.com/webforj/webforj/issues
+    about: Report issues related to the core webforj framework here.
+  - name: webforJ Documentation
+    url: https://docs.webforj.com/
+    about: Learn more about webforJ
+  - name: Contact Us
+    url: https://webforj.com/schedule-discovery/
+    about: Interested in webforJ? Book a short meeting, you'll discover what webforJ is, and we'll discuss how it can best meet your needs in preparation for a robust demonstration.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature Request
+description: Suggest an idea for a new addon or an enhancement to an existing one
+title: "[Feature]: "
+labels: ["type: enhancement", "status: needs triage"]
+type: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an idea! Please provide details about your feature request. Before submitting, please search for similar feature requests in the issues section to avoid duplicates.
+  - type: textarea
+    id: problem-description
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+      placeholder: "E.g., When working on large options, I find it difficult to find the right option in the list."
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+      placeholder: "E.g., I would like to have a search bar at the top of the options list to quickly filter options."
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+      placeholder: "E.g., I could manually search through the list, but this is time-consuming."
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context, mockups, or screenshots about the feature request here.
+      placeholder: "E.g., Screenshots, mockups, or specific use cases where this feature would help."
+    validations:
+      required: false


### PR DESCRIPTION
### Description
This PR introduces standardized issue templates for the `webforj-addons` repository to improve the quality and consistency of bug reports and feature requests submitted by contributors.

#### Benefits
- Ensures contributors provide necessary information upfront.
- Helps maintainers triage and address issues more efficiently.
- Provides a consistent experience for submitting issues.