### PR TITLE
feat: enhance item management API and refactor Item class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,31 @@
     <webforj.version>25.00-SNAPSHOT</webforj.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>5.12.2</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>5.17.0</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>5.17.0</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <repositories>
     <repository>
       <releases>

--- a/webforj-addons-components/webforj-multi-select-combo/pom.xml
+++ b/webforj-addons-components/webforj-multi-select-combo/pom.xml
@@ -26,5 +26,23 @@
       <artifactId>webforj-components-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/webforj-addons-components/webforj-multi-select-combo/src/main/java/com/webforj/addons/components/multiselectcombo/Item.java
+++ b/webforj-addons-components/webforj-multi-select-combo/src/main/java/com/webforj/addons/components/multiselectcombo/Item.java
@@ -5,11 +5,12 @@ package com.webforj.addons.components.multiselectcombo;
  * value, a label, optional prefix and suffix text, and a flag indicating whether the item is
  * disabled.
  *
- * <p>
- *
+ * @deprecated Use {@link MultiSelectComboItem} and its builder pattern instead. This class is
+ *     scheduled for removal in a future release.
  * @author ElyasSalar
  * @since 1.00
  */
+@Deprecated(since = "24.22", forRemoval = true)
 public class Item {
 
   /** The value associated with the item. */
@@ -32,7 +33,9 @@ public class Item {
    *
    * @param value The value associated with the item.
    * @param label The label displayed for the item.
+   * @deprecated Use {@link MultiSelectComboItem#builder()} instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item(String value, String label) {
     this.value = value;
     this.label = label;
@@ -46,7 +49,9 @@ public class Item {
    * @param prefix The prefix text displayed before the label.
    * @param suffix The suffix text displayed after the label.
    * @param disabled A flag indicating whether the item is disabled.
+   * @deprecated Use {@link MultiSelectComboItem#builder()} instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item(String value, String label, String prefix, String suffix, Boolean disabled) {
     this.value = value;
     this.label = label;
@@ -59,7 +64,9 @@ public class Item {
    * Retrieves the value associated with the item.
    *
    * @return The value of the item.
+   * @deprecated Use {@link MultiSelectComboItem#getValue()} instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public String getValue() {
     return value;
   }
@@ -69,7 +76,9 @@ public class Item {
    *
    * @param value The value to set.
    * @return This {@code Item} instance for method chaining.
+   * @deprecated Use {@link MultiSelectComboItem#setValue(String)} or the builder instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setValue(String value) {
     this.value = value;
     return this;
@@ -79,7 +88,9 @@ public class Item {
    * Retrieves the label displayed for the item.
    *
    * @return The label of the item.
+   * @deprecated Use {@link MultiSelectComboItem#getLabel()} instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public String getLabel() {
     return label;
   }
@@ -89,7 +100,9 @@ public class Item {
    *
    * @param label The label to set.
    * @return This {@code Item} instance for method chaining.
+   * @deprecated Use {@link MultiSelectComboItem#setLabel(String)} or the builder instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setLabel(String label) {
     this.label = label;
     return this;
@@ -99,7 +112,9 @@ public class Item {
    * Retrieves the prefix text displayed before the label.
    *
    * @return The prefix text of the item.
+   * @deprecated Use {@link MultiSelectComboItem#getPrefix()} instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public String getPrefix() {
     return prefix;
   }
@@ -109,7 +124,9 @@ public class Item {
    *
    * @param prefix The prefix text to set.
    * @return This {@code Item} instance for method chaining.
+   * @deprecated Use {@link MultiSelectComboItem#setPrefix(String)} or the builder instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setPrefix(String prefix) {
     this.prefix = prefix;
     return this;
@@ -119,7 +136,9 @@ public class Item {
    * Retrieves the suffix text displayed after the label.
    *
    * @return The suffix text of the item.
+   * @deprecated Use {@link MultiSelectComboItem#getSuffix()} instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public String getSuffix() {
     return suffix;
   }
@@ -129,7 +148,9 @@ public class Item {
    *
    * @param suffix The suffix text to set.
    * @return This {@code Item} instance for method chaining.
+   * @deprecated Use {@link MultiSelectComboItem#setSuffix(String)} or the builder instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setSuffix(String suffix) {
     this.suffix = suffix;
     return this;
@@ -139,7 +160,10 @@ public class Item {
    * Retrieves the flag indicating whether the item is disabled.
    *
    * @return {@code true} if the item is disabled, {@code false} otherwise.
+   * @deprecated Use {@link MultiSelectComboItem#isDisabled()} instead. Note the potential change
+   *     from {@code Boolean} to {@code boolean}.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Boolean getDisabled() {
     return disabled;
   }
@@ -149,7 +173,9 @@ public class Item {
    *
    * @param disabled The flag to set.
    * @return This {@code Item} instance for method chaining.
+   * @deprecated Use {@link MultiSelectComboItem#setDisabled(boolean)} or the builder instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setDisabled(Boolean disabled) {
     this.disabled = disabled;
     return this;

--- a/webforj-addons-components/webforj-multi-select-combo/src/main/java/com/webforj/addons/components/multiselectcombo/MultiSelectCombo.java
+++ b/webforj-addons-components/webforj-multi-select-combo/src/main/java/com/webforj/addons/components/multiselectcombo/MultiSelectCombo.java
@@ -29,7 +29,11 @@ import com.webforj.data.selection.SelectionRange;
 import com.webforj.dispatcher.EventListener;
 import com.webforj.dispatcher.ListenerRegistration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A multi-select combo component designed for webforj. The {@code MultiSelectCombo} enables users
@@ -138,7 +142,7 @@ public class MultiSelectCombo extends ElementComposite
       PropertyDescriptor.property("renderer", null);
 
   /** Property for the list of items displayed by the component. */
-  private final PropertyDescriptor<List<Item>> itemsProp =
+  private final PropertyDescriptor<List<MultiSelectComboItem>> itemsProp =
       PropertyDescriptor.property("items", null);
 
   /** Property for the list of selected items in the component. */
@@ -406,6 +410,132 @@ public class MultiSelectCombo extends ElementComposite
   }
 
   /**
+   * Adds a single item to the combo box list.
+   *
+   * @param item The {@link MultiSelectComboItem} to add. Cannot be null.
+   * @return This {@code MultiSelectCombo} instance for method chaining.
+   * @throws NullPointerException if item is null.
+   */
+  public MultiSelectCombo addItem(MultiSelectComboItem item) {
+    Objects.requireNonNull(item, "Item cannot be null");
+    final var updatedItems = getMutableItemsList();
+    updatedItems.add(item);
+    return setItems(updatedItems);
+  }
+
+  /**
+   * Convenience method to create and add a simple item with only a label and value.
+   *
+   * @param label The text displayed to the user. Cannot be null.
+   * @param value The internal value associated with the item. Cannot be null.
+   * @return This {@code MultiSelectCombo} instance for method chaining.
+   */
+  public MultiSelectCombo addItem(String label, String value) {
+    final var item = MultiSelectComboItem.builder().label(label).value(value).build();
+    return addItem(item);
+  }
+
+  /**
+   * Adds multiple items to the combo box list.
+   *
+   * @param items The {@link MultiSelectComboItem}s to add. Cannot be null.
+   * @return This {@code MultiSelectCombo} instance for method chaining.
+   * @throws NullPointerException if items array is null or contains null elements.
+   */
+  public MultiSelectCombo addItems(MultiSelectComboItem... items) {
+    Objects.requireNonNull(items, "Items array cannot be null");
+    if (Arrays.stream(items).anyMatch(Objects::isNull)) {
+      throw new NullPointerException("Items array cannot contain null elements");
+    }
+    final var updatedItems = getMutableItemsList();
+    updatedItems.addAll(Arrays.asList(items));
+    if (!updatedItems.isEmpty()) {
+      return setItems(updatedItems);
+    }
+    return this;
+  }
+
+  /**
+   * Adds a collection of items to the combo box list.
+   *
+   * @param items A collection of {@link MultiSelectComboItem}s to add. Cannot be null.
+   * @return This {@code MultiSelectCombo} instance for method chaining.
+   * @throws NullPointerException if the collection is null or contains null elements.
+   */
+  public MultiSelectCombo addItems(Collection<MultiSelectComboItem> items) {
+    Objects.requireNonNull(items, "Items collection cannot be null");
+    if (items.stream().anyMatch(Objects::isNull)) {
+      throw new NullPointerException("Items collection cannot contain null elements");
+    }
+
+    final var updatedItems = getMutableItemsList();
+    updatedItems.addAll(items);
+    if (!updatedItems.isEmpty()) {
+      return setItems(updatedItems);
+    }
+    return this;
+  }
+
+  /**
+   * Removes a specific item from the combo box list based on the item's value.
+   *
+   * @param item The {@link MultiSelectComboItem} to remove. Comparison is based on the item's
+   *     value.
+   * @return This {@code MultiSelectCombo} instance for method chaining. Returns immediately if the
+   *     item is null or the current list is empty/null.
+   */
+  public MultiSelectCombo removeItem(MultiSelectComboItem item) {
+    if (item == null) {
+      return this;
+    }
+    return removeItemByValue(item.getValue());
+  }
+
+  /**
+   * Removes an item from the combo box list based on its value.
+   *
+   * @param value The value of the item to remove.
+   * @return This {@code MultiSelectCombo} instance for method chaining. Returns immediately if the
+   *     value is null or the current list is empty/null.
+   */
+  public MultiSelectCombo removeItemByValue(String value) {
+    if (value == null) {
+      return this;
+    }
+    final var currentItems = getItems();
+    if (currentItems == null || currentItems.isEmpty()) {
+      return this;
+    }
+
+    final var updatedItems = new ArrayList<>(currentItems);
+    boolean removed = updatedItems.removeIf(currentItem -> value.equals(currentItem.getValue()));
+
+    if (removed) {
+      return setItems(updatedItems);
+    }
+    return this;
+  }
+
+  /**
+   * Removes all items from the combo box list.
+   *
+   * @return This {@code MultiSelectCombo} instance for method chaining.
+   */
+  public MultiSelectCombo clearItems() {
+    setItems(Collections.emptyList());
+    return this;
+  }
+
+  private List<MultiSelectComboItem> getMutableItemsList() {
+    final var currentItems = getItems();
+    if (currentItems == null) {
+      return new ArrayList<>();
+    } else {
+      return new ArrayList<>(currentItems);
+    }
+  }
+
+  /**
    * Retrieves the current caret position within the component's input field.
    *
    * <p>This method returns the index of the caret's position, which can be used to determine where
@@ -578,18 +708,18 @@ public class MultiSelectCombo extends ElementComposite
    *
    * @return The items value.
    */
-  public List<Item> getItems() {
+  public List<MultiSelectComboItem> getItems() {
     return get(this.itemsProp);
   }
 
   /**
    * Sets the list of items of the control.
    *
-   * @param items The items value.
+   * @param multiSelectComboItems The items value.
    * @return This {@code MultiSelectCombo} instance for method chaining.
    */
-  public MultiSelectCombo setItems(List<Item> items) {
-    set(this.itemsProp, items);
+  public MultiSelectCombo setItems(List<MultiSelectComboItem> multiSelectComboItems) {
+    set(this.itemsProp, multiSelectComboItems);
     return this;
   }
 

--- a/webforj-addons-components/webforj-multi-select-combo/src/main/java/com/webforj/addons/components/multiselectcombo/MultiSelectComboItem.java
+++ b/webforj-addons-components/webforj-multi-select-combo/src/main/java/com/webforj/addons/components/multiselectcombo/MultiSelectComboItem.java
@@ -1,0 +1,270 @@
+package com.webforj.addons.components.multiselectcombo;
+
+import java.util.Objects;
+
+/**
+ * Represents a selectable item within a {@link MultiSelectCombo} component.
+ *
+ * <p>Each {@code MultiSelectComboItem} encapsulates essential properties for an item in the combo
+ * box's dropdown list, including its underlying value, display label, optional visual prefixes or
+ * suffixes, and its enabled/disabled state.
+ *
+ * @author ElyasSalar
+ * @since 24.22
+ */
+public class MultiSelectComboItem {
+  private static final String VALUE_NULL_ERROR_MESSAGE = "Value cannot be null";
+  private static final String LABEL_NULL_ERROR_MESSAGE = "Label cannot be null";
+
+  /** The internal value associated with the item, used for identification and data binding. */
+  private String value;
+
+  /** The text displayed to the user for this item in the dropdown list. */
+  private String label;
+
+  /** Optional HTML or text content displayed before the item's label. */
+  private String prefix;
+
+  /** Optional HTML or text content displayed after the item's label. */
+  private String suffix;
+
+  /** A flag indicating whether the item can be selected by the user. */
+  private boolean disabled;
+
+  /**
+   * Private constructor used by the Builder.
+   *
+   * @param builder The builder instance containing the properties to set.
+   */
+  private MultiSelectComboItem(Builder builder) {
+    Objects.requireNonNull(builder.label, LABEL_NULL_ERROR_MESSAGE);
+    Objects.requireNonNull(builder.value, VALUE_NULL_ERROR_MESSAGE);
+
+    this.value = builder.value;
+    this.label = builder.label;
+    this.prefix = builder.prefix;
+    this.suffix = builder.suffix;
+    this.disabled = builder.disabled;
+  }
+
+  /**
+   * Retrieves the internal value associated with this item. This value is typically used for data
+   * processing or identification when the item is selected.
+   *
+   * @return The non-null internal value of the item.
+   */
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Sets the internal value associated with this item.
+   *
+   * @param value The non-null value to set.
+   * @return This {@code MultiSelectComboItem} instance for method chaining.
+   * @throws NullPointerException if value is null.
+   */
+  public MultiSelectComboItem setValue(String value) {
+    Objects.requireNonNull(value, VALUE_NULL_ERROR_MESSAGE);
+    this.value = value;
+    return this;
+  }
+
+  /**
+   * Retrieves the text label displayed for this item in the combo box list.
+   *
+   * @return The non-null display label of the item.
+   */
+  public String getLabel() {
+    return label;
+  }
+
+  /**
+   * Sets the text label displayed for this item.
+   *
+   * @param label The non-null label to set.
+   * @return This {@code MultiSelectComboItem} instance for method chaining.
+   * @throws NullPointerException if label is null.
+   */
+  public MultiSelectComboItem setLabel(String label) {
+    Objects.requireNonNull(label, LABEL_NULL_ERROR_MESSAGE);
+    this.label = label;
+    return this;
+  }
+
+  /**
+   * Retrieves the optional prefix content (HTML or text) displayed before the item's label.
+   *
+   * @return The prefix content, or null if none is set.
+   */
+  public String getPrefix() {
+    return prefix;
+  }
+
+  /**
+   * Sets the optional prefix content (HTML or text) displayed before the item's label.
+   *
+   * @param prefix The prefix content to set.
+   * @return This {@code MultiSelectComboItem} instance for method chaining.
+   */
+  public MultiSelectComboItem setPrefix(String prefix) {
+    this.prefix = prefix;
+    return this;
+  }
+
+  /**
+   * Retrieves the optional suffix content (HTML or text) displayed after the item's label.
+   *
+   * @return The suffix content, or null if none is set.
+   */
+  public String getSuffix() {
+    return suffix;
+  }
+
+  /**
+   * Sets the optional suffix content (HTML or text) displayed after the item's label.
+   *
+   * @param suffix The suffix content to set.
+   * @return This {@code MultiSelectComboItem} instance for method chaining.
+   */
+  public MultiSelectComboItem setSuffix(String suffix) {
+    this.suffix = suffix;
+    return this;
+  }
+
+  /**
+   * Retrieves the flag indicating whether the item is disabled (cannot be selected). Defaults to
+   * false if not explicitly set.
+   *
+   * @return {@code true} if the item is disabled, {@code false} otherwise.
+   */
+  public boolean isDisabled() {
+    return disabled;
+  }
+
+  /**
+   * Sets the flag indicating whether the item is disabled (cannot be selected).
+   *
+   * @param disabled The disabled state to set (true for disabled, false for enabled). If null, it
+   *     defaults to false.
+   * @return This {@code MultiSelectComboItem} instance for method chaining.
+   */
+  public MultiSelectComboItem setDisabled(boolean disabled) {
+    this.disabled = disabled;
+    return this;
+  }
+
+  /**
+   * Creates a new builder instance to construct a {@code MultiSelectComboItem}. This is the
+   * recommended way to create items.
+   *
+   * @return An {@link ILabel} instance to start the building process.
+   */
+  public static ILabel builder() {
+    return new Builder();
+  }
+
+  /** Enforces setting the label first. */
+  public interface ILabel {
+    /**
+     * Sets the mandatory display label for the item.
+     *
+     * @param label The text displayed to the user. Cannot be null.
+     * @return The next step in the builder process (setting the value).
+     */
+    IValue label(String label);
+  }
+
+  /** Enforces setting the value second. */
+  public interface IValue {
+    /**
+     * Sets the mandatory internal value for the item.
+     *
+     * @param value The internal value associated with the item. Cannot be null.
+     * @return The next step in the builder process (setting optional attributes).
+     */
+    IBuild value(String value);
+  }
+
+  /** Allows setting optional properties and building the item. */
+  public interface IBuild {
+    /**
+     * Sets the optional prefix content (HTML or text) displayed before the item's label.
+     *
+     * @param prefix The prefix content.
+     * @return This builder instance for further configuration.
+     */
+    IBuild prefix(String prefix);
+
+    /**
+     * Sets the optional suffix content (HTML or text) displayed after the item's label.
+     *
+     * @param suffix The suffix content.
+     * @return This builder instance for further configuration.
+     */
+    IBuild suffix(String suffix);
+
+    /**
+     * Sets the disabled state of the item. If not called, the item defaults to enabled (false).
+     *
+     * @param disabled True to disable the item, false to enable it.
+     * @return This builder instance for further configuration.
+     */
+    IBuild disabled(boolean disabled);
+
+    /**
+     * Constructs the final {@code MultiSelectComboItem} instance.
+     *
+     * @return The fully configured {@code MultiSelectComboItem}.
+     */
+    MultiSelectComboItem build();
+  }
+
+  /** Private implementation of the builder steps. */
+  private static class Builder implements ILabel, IValue, IBuild {
+    private String value;
+    private String label;
+    private String prefix;
+    private String suffix;
+    private boolean disabled = false;
+
+    private Builder() {}
+
+    @Override
+    public IValue label(String label) {
+      Objects.requireNonNull(label, LABEL_NULL_ERROR_MESSAGE);
+      this.label = label;
+      return this;
+    }
+
+    @Override
+    public IBuild value(String value) {
+      Objects.requireNonNull(value, VALUE_NULL_ERROR_MESSAGE);
+      this.value = value;
+      return this;
+    }
+
+    @Override
+    public IBuild prefix(String prefix) {
+      this.prefix = prefix;
+      return this;
+    }
+
+    @Override
+    public IBuild suffix(String suffix) {
+      this.suffix = suffix;
+      return this;
+    }
+
+    @Override
+    public IBuild disabled(boolean disabled) {
+      this.disabled = disabled;
+      return this;
+    }
+
+    @Override
+    public MultiSelectComboItem build() {
+      return new MultiSelectComboItem(this);
+    }
+  }
+}

--- a/webforj-addons-components/webforj-multi-select-combo/src/main/java/com/webforj/addons/components/multiselectcombo/events/SelectedChangedEvent.java
+++ b/webforj-addons-components/webforj-multi-select-combo/src/main/java/com/webforj/addons/components/multiselectcombo/events/SelectedChangedEvent.java
@@ -2,8 +2,8 @@ package com.webforj.addons.components.multiselectcombo.events;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.webforj.addons.components.multiselectcombo.Item;
 import com.webforj.addons.components.multiselectcombo.MultiSelectCombo;
+import com.webforj.addons.components.multiselectcombo.MultiSelectComboItem;
 import com.webforj.component.element.annotation.EventName;
 import com.webforj.component.element.annotation.EventOptions;
 import com.webforj.component.event.ComponentEvent;
@@ -31,9 +31,9 @@ public class SelectedChangedEvent extends ComponentEvent<MultiSelectCombo> {
   }
 
   /** Retrieves a list of selected items from the component's event map. */
-  public List<Item> getSelectedItems() {
+  public List<MultiSelectComboItem> getSelectedItems() {
     final var gson = new Gson();
-    final var type = new TypeToken<List<Item>>() {}.getType();
+    final var type = new TypeToken<List<MultiSelectComboItem>>() {}.getType();
     final var json = gson.toJson(this.getEventMap().get("selected"), List.class);
     return gson.fromJson(json, type);
   }

--- a/webforj-addons-components/webforj-multi-select-combo/src/test/java/com/webforj/addons/components/multiselectcombo/MultiSelectComboItemTest.java
+++ b/webforj-addons-components/webforj-multi-select-combo/src/test/java/com/webforj/addons/components/multiselectcombo/MultiSelectComboItemTest.java
@@ -1,0 +1,238 @@
+package com.webforj.addons.components.multiselectcombo;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MultiSelectComboItem Tests")
+class MultiSelectComboItemTest {
+
+  private static final String DEFAULT_LABEL = "Default Label";
+  private static final String DEFAULT_VALUE = "default_value";
+
+  @Nested
+  @DisplayName("Builder Tests")
+  class BuilderTests {
+
+    @Test
+    @DisplayName("should build item with only mandatory fields")
+    void buildWithMandatoryFields() {
+      final var item =
+        MultiSelectComboItem.builder().label(DEFAULT_LABEL).value(DEFAULT_VALUE).build();
+
+      assertNotNull(item);
+      assertEquals(DEFAULT_LABEL, item.getLabel());
+      assertEquals(DEFAULT_VALUE, item.getValue());
+      assertNull(item.getPrefix());
+      assertNull(item.getSuffix());
+      assertFalse(item.isDisabled(), "Disabled should default to false");
+    }
+
+    @Test
+    @DisplayName("should build item with all optional fields")
+    void buildWithAllFields() {
+      final var prefix = "Pre:";
+      final var suffix = ":Suf";
+      final boolean disabled = true;
+
+      final var item = MultiSelectComboItem.builder()
+          .label(DEFAULT_LABEL)
+          .value(DEFAULT_VALUE)
+          .prefix(prefix)
+          .suffix(suffix)
+          .disabled(disabled)
+          .build();
+
+      assertNotNull(item);
+      assertEquals(DEFAULT_LABEL, item.getLabel());
+      assertEquals(DEFAULT_VALUE, item.getValue());
+      assertEquals(prefix, item.getPrefix());
+      assertEquals(suffix, item.getSuffix());
+      assertEquals(disabled, item.isDisabled());
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException when mandatory label is null")
+    void buildWithNullLabel() {
+      final var builderStep1 = MultiSelectComboItem.builder();
+      final var exception = assertThrows(NullPointerException.class, () -> {
+        builderStep1.label(null);
+      });
+      assertEquals("Label cannot be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException when mandatory value is null")
+    void buildWithNullValue() {
+      final var builderStep2 = MultiSelectComboItem.builder().label(DEFAULT_LABEL);
+      final var exception = assertThrows(NullPointerException.class, () -> {
+        builderStep2.value(null);
+      });
+      assertEquals("Value cannot be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("should have default value for disabled field when not set")
+    void buildWithDefaultDisabled() {
+      final var item =
+        MultiSelectComboItem.builder().label(DEFAULT_LABEL).value(DEFAULT_VALUE).build();
+      assertFalse(item.isDisabled());
+    }
+  }
+
+  @Nested
+  @DisplayName("Getter Tests")
+  class GetterTests {
+
+    private MultiSelectComboItem item;
+    private final String prefix = "Prefix ";
+    private final String suffix = " Suffix";
+
+    @BeforeEach
+    void setUp() {
+      item =
+        MultiSelectComboItem.builder()
+          .label(DEFAULT_LABEL)
+          .value(DEFAULT_VALUE)
+          .prefix(prefix)
+          .suffix(suffix)
+          .disabled(true)
+          .build();
+    }
+
+    @Test
+    @DisplayName("getLabel() returns correct value")
+    void getLabel() {
+      assertEquals(DEFAULT_LABEL, item.getLabel());
+    }
+
+    @Test
+    @DisplayName("getValue() returns correct value")
+    void getValue() {
+      assertEquals(DEFAULT_VALUE, item.getValue());
+    }
+
+    @Test
+    @DisplayName("getPrefix() returns correct value")
+    void getPrefix() {
+      assertEquals(prefix, item.getPrefix());
+    }
+
+    @Test
+    @DisplayName("getSuffix() returns correct value")
+    void getSuffix() {
+      assertEquals(suffix, item.getSuffix());
+    }
+
+    @Test
+    @DisplayName("isDisabled() returns correct value")
+    void isDisabled() {
+      assertTrue(item.isDisabled());
+    }
+  }
+
+  @Nested
+  @DisplayName("Setter Tests")
+  class SetterTests {
+
+    private MultiSelectComboItem item;
+
+    @BeforeEach
+    void setUp() {
+      item = MultiSelectComboItem.builder().label(DEFAULT_LABEL).value(DEFAULT_VALUE).build();
+    }
+
+    @Test
+    @DisplayName("setLabel() updates value and returns this")
+    void setLabel() {
+      final var newLabel = "New Label";
+      final var returnedItem = item.setLabel(newLabel);
+      assertEquals(newLabel, item.getLabel());
+      assertSame(item, returnedItem);
+    }
+
+    @Test
+    @DisplayName("setValue() updates value and returns this")
+    void setValue() {
+      final var newValue = "new_value";
+      final var returnedItem = item.setValue(newValue);
+      assertEquals(newValue, item.getValue());
+      assertSame(item, returnedItem);
+    }
+
+    @Test
+    @DisplayName("setPrefix() updates value and returns this")
+    void setPrefix() {
+      final var newPrefix = "New Pre";
+      final var returnedItem = item.setPrefix(newPrefix);
+      assertEquals(newPrefix, item.getPrefix());
+      assertSame(item, returnedItem);
+    }
+
+    @Test
+    @DisplayName("setPrefix() accepts null")
+    void setPrefixNull() {
+      item.setPrefix("Initial");
+      final var returnedItem = item.setPrefix(null);
+      assertNull(item.getPrefix());
+      assertSame(item, returnedItem);
+    }
+
+    @Test
+    @DisplayName("setSuffix() updates value and returns this")
+    void setSuffix() {
+      final var newSuffix = "New Suf";
+      final var returnedItem = item.setSuffix(newSuffix);
+      assertEquals(newSuffix, item.getSuffix());
+      assertSame(item, returnedItem);
+    }
+
+    @Test
+    @DisplayName("setSuffix() accepts null")
+    void setSuffixNull() {
+      item.setSuffix("Initial");
+      final var returnedItem = item.setSuffix(null);
+      assertNull(item.getSuffix());
+      assertSame(item, returnedItem);
+    }
+
+    @Test
+    @DisplayName("setDisabled() updates value and returns this")
+    void setDisabled() {
+      var returnedItem = item.setDisabled(true);
+      assertTrue(item.isDisabled());
+      assertSame(item, returnedItem);
+
+      returnedItem = item.setDisabled(false);
+      assertFalse(item.isDisabled());
+      assertSame(item, returnedItem);
+    }
+
+    @Test
+    @DisplayName("setLabel() should throw NullPointerException for null label")
+    void setLabelNull() {
+      final var exception =
+        assertThrows(
+          NullPointerException.class,
+          () -> {
+            item.setLabel(null);
+          });
+      assertEquals("Label cannot be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("setValue() should throw NullPointerException for null value")
+    void setValueNull() {
+      final var exception =
+        assertThrows(
+          NullPointerException.class,
+          () -> {
+            item.setValue(null);
+          });
+      assertEquals("Value cannot be null", exception.getMessage());
+    }
+  }
+}

--- a/webforj-addons-components/webforj-multi-select-combo/src/test/java/com/webforj/addons/components/multiselectcombo/MultiSelectComboTest.java
+++ b/webforj-addons-components/webforj-multi-select-combo/src/test/java/com/webforj/addons/components/multiselectcombo/MultiSelectComboTest.java
@@ -1,0 +1,416 @@
+package com.webforj.addons.components.multiselectcombo;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@DisplayName("MultiSelectCombo Item Manipulation Tests")
+@ExtendWith(MockitoExtension.class)
+class MultiSelectComboTest {
+
+  @Spy MultiSelectCombo multiSelectCombo = new MultiSelectCombo();
+
+  @Captor ArgumentCaptor<List<MultiSelectComboItem>> itemsListCaptor;
+
+  private MultiSelectComboItem item1;
+  private MultiSelectComboItem item2;
+  private MultiSelectComboItem item3;
+
+  @BeforeEach
+  void setUp() {
+    item1 = MultiSelectComboItem.builder().label("Label 1").value("value1").build();
+    item2 = MultiSelectComboItem.builder().label("Label 2").value("value2").disabled(true).build();
+    item3 = MultiSelectComboItem.builder().label("Label 3").value("value3").build();
+
+    multiSelectCombo.setItems(new ArrayList<>(Arrays.asList(item1, item2)));
+    clearInvocations(multiSelectCombo);
+  }
+
+  @Nested
+  @DisplayName("addItem(MultiSelectComboItem item)")
+  class AddSingleItemTests {
+
+    @Test
+    @DisplayName("should add item to an empty list")
+    void addItemToEmptyList() {
+      multiSelectCombo.setItems(new ArrayList<>());
+      clearInvocations(multiSelectCombo);
+
+      final var returned = multiSelectCombo.addItem(item3);
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      List<MultiSelectComboItem> capturedList = itemsListCaptor.getValue();
+      assertEquals(1, capturedList.size());
+      assertEquals(item3, capturedList.get(0));
+      assertSame(multiSelectCombo, returned, "Should return instance for chaining");
+    }
+
+    @Test
+    @DisplayName("should add item to the end of an existing list")
+    void addItemToExistingList() {
+      final var returned = multiSelectCombo.addItem(item3);
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(3, capturedList.size());
+      assertEquals(item1, capturedList.get(0));
+      assertEquals(item2, capturedList.get(1));
+      assertEquals(item3, capturedList.get(2));
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException when adding null item")
+    void addNullItem() {
+      assertThrows(NullPointerException.class, () -> multiSelectCombo.addItem(null),
+        "Item cannot be null");
+      verify(multiSelectCombo, never()).setItems(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("addItem(String label, String value)")
+  class AddLabelValueItemTests {
+
+    @Test
+    @DisplayName("should add item with label/value to an empty list")
+    void addItemToEmptyList() {
+      multiSelectCombo.setItems(new ArrayList<>());
+      clearInvocations(multiSelectCombo);
+
+      final var returned = multiSelectCombo.addItem("New Label", "new_value");
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(1, capturedList.size());
+      assertEquals("New Label", capturedList.get(0).getLabel());
+      assertEquals("new_value", capturedList.get(0).getValue());
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should add item with label/value to an existing list")
+    void addItemToExistingList() {
+      final var returned = multiSelectCombo.addItem("New Label", "new_value");
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(3, capturedList.size());
+      assertEquals(item1, capturedList.get(0));
+      assertEquals(item2, capturedList.get(1));
+      assertEquals("New Label", capturedList.get(2).getLabel());
+      assertEquals("new_value", capturedList.get(2).getValue());
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException if label is null")
+    void addNullLabel() {
+      assertThrows(NullPointerException.class,
+        () -> multiSelectCombo.addItem(null, "value"),
+        "Label cannot be null (from builder)");
+      verify(multiSelectCombo, never()).setItems(any());
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException if value is null")
+    void addNullValue() {
+      assertThrows(NullPointerException.class,
+        () -> multiSelectCombo.addItem("Label", null),
+        "Value cannot be null (from builder)");
+      verify(multiSelectCombo, never()).setItems(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("addItems(MultiSelectComboItem... items)")
+  class AddVarArgsItemsTests {
+
+    @Test
+    @DisplayName("should add multiple items to an empty list")
+    void addItemsToEmptyList() {
+      multiSelectCombo.setItems(new ArrayList<>());
+      clearInvocations(multiSelectCombo);
+
+      final var returned = multiSelectCombo.addItems(item1, item2);
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(2, capturedList.size());
+      assertEquals(item1, capturedList.get(0));
+      assertEquals(item2, capturedList.get(1));
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should add multiple items to an existing list")
+    void addItemsToExistingList() {
+      final var item4 = MultiSelectComboItem.builder().label("Label 4").value("value4").build();
+      final var returned = multiSelectCombo.addItems(item3, item4);
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(4, capturedList.size());
+      assertEquals(item1, capturedList.get(0));
+      assertEquals(item2, capturedList.get(1));
+      assertEquals(item3, capturedList.get(2));
+      assertEquals(item4, capturedList.get(3));
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should do nothing when adding empty varargs")
+    void addEmptyVarArgs() {
+      multiSelectCombo.setItems(new ArrayList<>());
+      clearInvocations(multiSelectCombo);
+
+      final var returned = multiSelectCombo.addItems();
+      verify(multiSelectCombo, never()).setItems(any());
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException if items array is null")
+    void addNullVarArgsArray() {
+      assertThrows(NullPointerException.class,
+        () -> multiSelectCombo.addItems((MultiSelectComboItem[]) null),
+        "Items array cannot be null");
+      verify(multiSelectCombo, never()).setItems(any());
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException if items array contains null")
+    void addVarArgsWithNullElement() {
+      assertThrows(NullPointerException.class,
+        () -> multiSelectCombo.addItems(item1, null, item2),
+        "Items array cannot contain null elements");
+      verify(multiSelectCombo, never()).setItems(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("addItems(Collection<MultiSelectComboItem> items)")
+  class AddCollectionItemsTests {
+
+    @Test
+    @DisplayName("should add collection items to an empty list")
+    void addCollectionToEmptyList() {
+      multiSelectCombo.setItems(new ArrayList<>());
+      clearInvocations(multiSelectCombo);
+      final var itemsToAdd = Arrays.asList(item1, item2);
+
+      MultiSelectCombo returned = multiSelectCombo.addItems(itemsToAdd);
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(2, capturedList.size());
+      assertEquals(item1, capturedList.get(0));
+      assertEquals(item2, capturedList.get(1));
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should add collection items to an existing list")
+    void addCollectionToExistingList() {
+      // Initial state: [item1, item2]
+      final var item4 =
+        MultiSelectComboItem.builder().label("Label 4").value("value4").build();
+      final var itemsToAdd = Arrays.asList(item3, item4);
+      final var returned = multiSelectCombo.addItems(itemsToAdd);
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(4, capturedList.size());
+      assertEquals(item1, capturedList.get(0));
+      assertEquals(item2, capturedList.get(1));
+      assertEquals(item3, capturedList.get(2));
+      assertEquals(item4, capturedList.get(3));
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should do nothing when adding empty collection")
+    void addEmptyCollection() {
+      multiSelectCombo.setItems(new ArrayList<>());
+      clearInvocations(multiSelectCombo);
+
+      final var returned = multiSelectCombo.addItems(new ArrayList<>());
+      verify(multiSelectCombo, never()).setItems(any());
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException if collection is null")
+    void addNullCollection() {
+      assertThrows(NullPointerException.class,
+        () -> multiSelectCombo.addItems((Collection<MultiSelectComboItem>) null),
+        "Items collection cannot be null");
+      verify(multiSelectCombo, never()).setItems(any());
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException if collection contains null")
+    void addCollectionWithNullElement() {
+      final var itemsToAdd = Arrays.asList(item1, null, item2);
+      assertThrows(NullPointerException.class,
+        () -> multiSelectCombo.addItems(itemsToAdd),
+        "Items collection cannot contain null elements");
+      verify(multiSelectCombo, never()).setItems(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("removeItem(MultiSelectComboItem item)")
+  class RemoveItemObjectTests {
+
+    @Test
+    @DisplayName("should call removeItemByValue with correct value")
+    void removeItemDelegatesCorrectly() {
+      final var returned = multiSelectCombo.removeItem(item1);
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(1, capturedList.size());
+      assertEquals("value2", capturedList.get(0).getValue());
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should do nothing if item is null")
+    void removeNullItemObject() {
+      final var returned = multiSelectCombo.removeItem(null);
+      verify(multiSelectCombo, never()).removeItemByValue(any());
+      verify(multiSelectCombo, never()).setItems(any());
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should do nothing if item to remove is not in the list")
+    void removeNonExistentItemObject() {
+      final var nonExistentItem = MultiSelectComboItem.builder()
+        .label("Non Existent")
+        .value("non_existent_value")
+        .build();
+      final var returned = multiSelectCombo.removeItem(nonExistentItem);
+      verify(multiSelectCombo).removeItemByValue("non_existent_value");
+      verify(multiSelectCombo, never()).setItems(any());
+      assertSame(multiSelectCombo, returned);
+    }
+  }
+
+  @Nested
+  @DisplayName("removeItemByValue(String value)")
+  class RemoveItemByValueTests {
+
+    @Test
+    @DisplayName("should remove item by value")
+    void removeItemValue() {
+      final var returned = multiSelectCombo.removeItemByValue("value1");
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(1, capturedList.size());
+      assertEquals("value2", capturedList.get(0).getValue());
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should remove correct item if multiple have same label but different value")
+    void removeByDistinctValue() {
+      final var item1b = MultiSelectComboItem.builder().label("Label 1").value("value1b").build();
+      multiSelectCombo.addItems(item1b);
+      clearInvocations(multiSelectCombo);
+
+      multiSelectCombo.removeItemByValue("value1");
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(2, capturedList.size());
+      assertTrue(capturedList.stream().anyMatch(it -> "value2".equals(it.getValue())));
+      assertTrue(capturedList.stream().anyMatch(it -> "value1b".equals(it.getValue())));
+      assertFalse(capturedList.stream().anyMatch(it -> "value1".equals(it.getValue())));
+    }
+
+
+    @Test
+    @DisplayName("should do nothing if value not found")
+    void removeNonExistentValue() {
+      final var returned = multiSelectCombo.removeItemByValue("non_existent_value");
+      verify(multiSelectCombo, never()).setItems(any());
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should do nothing if value is null")
+    void removeNullValue() {
+      final var returned = multiSelectCombo.removeItemByValue(null);
+      verify(multiSelectCombo, never()).setItems(any());
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should do nothing if list is empty")
+    void removeFromEmptyList() {
+      multiSelectCombo.setItems(new ArrayList<>());
+      clearInvocations(multiSelectCombo);
+      final var returned = multiSelectCombo.removeItemByValue("value1");
+      verify(multiSelectCombo, never()).setItems(any());
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should do nothing if list is null initially (handled by getItems)")
+    void removeFromNullList() {
+      final var comboWithNull = spy(new MultiSelectCombo());
+      doReturn(null).when(comboWithNull).getItems();
+
+      final var returned = comboWithNull.removeItemByValue("value1");
+
+      verify(comboWithNull, never()).setItems(any());
+      assertSame(comboWithNull, returned);
+    }
+
+  }
+
+  @Nested
+  @DisplayName("clearItems()")
+  class ClearItemsTests {
+
+    @Test
+    @DisplayName("should set items to an empty list when clearing non-empty list")
+    void clearNonEmptyList() {
+      final var returned = multiSelectCombo.clearItems();
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertNotNull(capturedList);
+      assertTrue(capturedList.isEmpty());
+      assertSame(multiSelectCombo, returned);
+    }
+
+    @Test
+    @DisplayName("should set items to an empty list when clearing an empty list")
+    void clearEmptyList() {
+      multiSelectCombo.setItems(new ArrayList<>());
+      clearInvocations(multiSelectCombo);
+
+      final var returned = multiSelectCombo.clearItems();
+
+      verify(multiSelectCombo).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertNotNull(capturedList);
+      assertTrue(capturedList.isEmpty());
+      assertSame(multiSelectCombo, returned);
+    }
+  }
+}


### PR DESCRIPTION
### Description
The previous API for managing items within the `MultiSelectCombo` component relied solely on the `setItems(List<Item> items)` method. This required developers to manually fetch, modify, and then set the entire list, even for simple additions or removals. This approach was cumbersome, less intuitive, and potentially error-prone.

The goal of this change is to provide a more seamless, flexible, and developer-friendly API for interacting with the component's items, making common operations much simpler.