### PR TITLE
feat: enhance item management API and refactor Item class for SideMenu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,31 @@
     <webforj.version>25.00-SNAPSHOT</webforj.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>5.12.2</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>5.17.0</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>5.17.0</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <repositories>
     <repository>
       <releases>

--- a/webforj-addons-components/webforj-side-menu/pom.xml
+++ b/webforj-addons-components/webforj-side-menu/pom.xml
@@ -27,5 +27,23 @@
       <artifactId>webforj-components-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/webforj-addons-components/webforj-side-menu/src/main/java/com/webforj/addons/components/sidemenu/Item.java
+++ b/webforj-addons-components/webforj-side-menu/src/main/java/com/webforj/addons/components/sidemenu/Item.java
@@ -11,7 +11,10 @@ import java.util.List;
  *
  * @since 1.00
  * @author ElyasSalar
+ * @deprecated Use {@link SideMenuItem} and its builder pattern instead. This class is scheduled for
+ *     removal.
  */
+@Deprecated(since = "24.22", forRemoval = true)
 public class Item {
   /** A unique identifier for the item. */
   private String id;
@@ -61,7 +64,12 @@ public class Item {
    */
   private List<Item> children;
 
-  /** Constructs a new {@code SideMenu} instance with the specified properties. */
+  /**
+   * Constructs a new {@code Item} instance with the specified properties.
+   *
+   * @deprecated Use {@link SideMenuItem#builder()} instead.
+   */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item(
       String id, String icon, String caption, String link, boolean favorite, List<Item> children) {
     this.id = id;
@@ -72,7 +80,12 @@ public class Item {
     this.children = children;
   }
 
-  /** Constructs a new {@code SideMenu} instance with the specified properties. */
+  /**
+   * Constructs a new {@code Item} instance with the specified properties.
+   *
+   * @deprecated Use {@link SideMenuItem#builder()} instead.
+   */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item(String id, String icon, String caption, String link, boolean favorite) {
     this(id, icon, caption, link, favorite, List.of());
   }
@@ -81,7 +94,9 @@ public class Item {
    * Gets the unique identifier for the item.
    *
    * @return The unique identifier for the item.
+   * @deprecated Use {@link SideMenuItem#getId()} instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public String getId() {
     return id;
   }
@@ -91,7 +106,9 @@ public class Item {
    *
    * @param id The unique identifier to set for the item.
    * @return The updated instance of the item.
+   * @deprecated Use {@link SideMenuItem#setId(String)} or the builder instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setId(String id) {
     this.id = id;
     return this;
@@ -101,7 +118,9 @@ public class Item {
    * Gets the icon associated with the item.
    *
    * @return The icon associated with the item.
+   * @deprecated Use {@link SideMenuItem#getIcon()} instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public String getIcon() {
     return icon;
   }
@@ -111,7 +130,9 @@ public class Item {
    *
    * @param icon The icon to set for the item.
    * @return The updated instance of the item.
+   * @deprecated Use {@link SideMenuItem#setIcon(String)} or the builder instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setIcon(String icon) {
     this.icon = icon;
     return this;
@@ -121,7 +142,9 @@ public class Item {
    * Gets the display text or caption for the item.
    *
    * @return The display text or caption for the item.
+   * @deprecated Use {@link SideMenuItem#getLabel()} instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public String getCaption() {
     return caption;
   }
@@ -131,7 +154,9 @@ public class Item {
    *
    * @param caption The display text or caption to set for the item.
    * @return The updated instance of the item.
+   * @deprecated Use {@link SideMenuItem#setLabel(String)} or the builder instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setCaption(String caption) {
     this.caption = caption;
     return this;
@@ -141,7 +166,9 @@ public class Item {
    * Gets the URL or link associated with the item.
    *
    * @return The URL or link associated with the item.
+   * @deprecated Use {@link SideMenuItem#getLink()} instead. The link can be a URL.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public String getLink() {
     return link;
   }
@@ -151,7 +178,9 @@ public class Item {
    *
    * @param link The URL or link to set for the item.
    * @return The updated instance of the item.
+   * @deprecated Use {@link SideMenuItem#setLink(String)} or the builder instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setLink(String link) {
     this.link = link;
     return this;
@@ -161,7 +190,9 @@ public class Item {
    * Checks if the link should be opened in a new tab.
    *
    * @return True if the link should be opened in a new tab, otherwise false.
+   * @deprecated Use {@link SideMenuItem#isNewTab()} instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public boolean isNewTab() {
     return newTab;
   }
@@ -171,7 +202,9 @@ public class Item {
    *
    * @param newTab True if the link should be opened in a new tab, otherwise false.
    * @return The updated instance of the item.
+   * @deprecated Use {@link SideMenuItem#setNewTab(boolean)} or the builder instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setNewTab(boolean newTab) {
     this.newTab = newTab;
     return this;
@@ -181,7 +214,9 @@ public class Item {
    * Gets the shortcut key associated with the item.
    *
    * @return The shortcut key associated with the item.
+   * @deprecated Use {@link SideMenuItem#getShortcut()} instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public String getShortcut() {
     return shortcut;
   }
@@ -191,7 +226,9 @@ public class Item {
    *
    * @param shortcut The shortcut key to set for the item.
    * @return The updated instance of the item.
+   * @deprecated Use {@link SideMenuItem#setShortcut(String)} or the builder instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setShortcut(String shortcut) {
     this.shortcut = shortcut;
     return this;
@@ -201,7 +238,9 @@ public class Item {
    * Checks if the item is marked as a favorite.
    *
    * @return True if the item is marked as a favorite, otherwise false.
+   * @deprecated Use {@link SideMenuItem#isFavorite()} instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public boolean isFavorite() {
     return favorite;
   }
@@ -211,7 +250,9 @@ public class Item {
    *
    * @param favorite True if the item is marked as a favorite, otherwise false.
    * @return The updated instance of the item.
+   * @deprecated Use {@link SideMenuItem#setFavorite(boolean)} or the builder instead.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setFavorite(boolean favorite) {
     this.favorite = favorite;
     return this;
@@ -221,7 +262,10 @@ public class Item {
    * Gets the children items of the current item.
    *
    * @return The children items of the current item.
+   * @deprecated Use {@link SideMenuItem#getChildren()} instead. The returned list will contain
+   *     {@code SideMenuItem} objects.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public List<Item> getChildren() {
     return children;
   }
@@ -231,7 +275,10 @@ public class Item {
    *
    * @param children The children items to set for the current item.
    * @return The updated instance of the item.
+   * @deprecated Use {@link SideMenuItem#setChildren(List)} or the builder instead. The list should
+   *     contain {@code SideMenuItem} objects.
    */
+  @Deprecated(since = "24.22", forRemoval = true)
   public Item setChildren(List<Item> children) {
     this.children = children;
     return this;

--- a/webforj-addons-components/webforj-side-menu/src/main/java/com/webforj/addons/components/sidemenu/SideMenuItem.java
+++ b/webforj-addons-components/webforj-side-menu/src/main/java/com/webforj/addons/components/sidemenu/SideMenuItem.java
@@ -1,0 +1,431 @@
+package com.webforj.addons.components.sidemenu;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents an individual item within the side menu of a webforj application.
+ *
+ * <p>Developers use {@code SideMenuItem} instances to construct hierarchical menus. Each item
+ * provides essential information for navigation and interaction within the {@link SideMenu}
+ * component. Items are typically created using the {@link #builder()} pattern.
+ *
+ * @since 24.22
+ * @author ElyasSalar
+ */
+public class SideMenuItem {
+
+  private static final String ID_NULL_ERROR_MESSAGE = "ID cannot be null";
+  private static final String LABEL_NULL_ERROR_MESSAGE = "Label cannot be null";
+
+  /** A unique identifier for the item, used for selection and events. */
+  private String id;
+
+  /**
+   * The icon associated with the item. It can be a string representing:
+   *
+   * <ul>
+   *   <li>URL: (e.g., {@code /path/to/image.png})
+   *   <li>Data URL: (e.g., {@code data:image/jpeg;base64,/9j/4...})
+   *   <li>Icon name: From the default dwc icons pool (e.g., {@code "x"}).
+   *   <li>Pool and name: {@code POOL_NAME:ICON_NAME} (e.g., {@code "feather:x"}).
+   * </ul>
+   */
+  private String icon;
+
+  /** The display text or label for the item shown to the user. */
+  private String label;
+
+  /**
+   * The URL or link associated with the item. When users interact with the item, they might be
+   * navigated to this link.
+   */
+  private String link;
+
+  /**
+   * Indicates whether the link should be opened in a new tab. If true, the link opens in a new
+   * browser tab/window; otherwise, it opens in the current tab (defaults to false).
+   */
+  private boolean newTab;
+
+  /**
+   * An optional shortcut key hint associated with the item. This can provide users with a visual
+   * cue for keyboard shortcuts.
+   */
+  private String shortcut;
+
+  /**
+   * Indicates whether the item is marked as a favorite (defaults to false). Users might be able to
+   * mark items as favorites for quick access.
+   */
+  private boolean favorite;
+
+  /**
+   * Child items of the current item, representing nested menu levels. Defaults to an empty list.
+   */
+  private List<SideMenuItem> children;
+
+  /**
+   * Private constructor used by the Builder.
+   *
+   * @param builder The builder instance containing the properties to set.
+   */
+  private SideMenuItem(Builder builder) {
+    Objects.requireNonNull(builder.id, ID_NULL_ERROR_MESSAGE);
+    Objects.requireNonNull(builder.label, LABEL_NULL_ERROR_MESSAGE);
+    this.id = builder.id;
+    this.label = builder.label;
+    this.icon = builder.icon;
+    this.link = builder.link;
+    this.newTab = builder.newTab;
+    this.shortcut = builder.shortcut;
+    this.favorite = builder.favorite;
+    this.children = (builder.children != null) ? builder.children : Collections.emptyList();
+  }
+
+  /**
+   * Copy constructor to create a new {@code SideMenuItem} based on an existing one. This is useful
+   * for creating a new item with the same properties as an existing one.
+   *
+   * @param item The existing {@code SideMenuItem} to copy.
+   */
+  public SideMenuItem(SideMenuItem item) {
+    this.id = item.id;
+    this.label = item.label;
+    this.icon = item.icon;
+    this.link = item.link;
+    this.newTab = item.newTab;
+    this.shortcut = item.shortcut;
+    this.favorite = item.favorite;
+    this.children = (item.children != null) ? item.children : Collections.emptyList();
+  }
+
+  /**
+   * Gets the unique identifier for the item.
+   *
+   * @return The non-null unique identifier for the item.
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * Gets the icon associated with the item.
+   *
+   * @return The icon string (URL, data URL, icon name, or pool:name), or null if not set.
+   */
+  public String getIcon() {
+    return icon;
+  }
+
+  /**
+   * Gets the display text or label for the item.
+   *
+   * @return The non-null display label for the item.
+   */
+  public String getLabel() {
+    return label;
+  }
+
+  /**
+   * Gets the URL or link associated with the item.
+   *
+   * @return The URL or link, or null if not set.
+   */
+  public String getLink() {
+    return link;
+  }
+
+  /**
+   * Checks if the link should be opened in a new tab.
+   *
+   * @return True if the link should be opened in a new tab, otherwise false.
+   */
+  public boolean isNewTab() {
+    return newTab;
+  }
+
+  /**
+   * Gets the shortcut key hint associated with the item.
+   *
+   * @return The shortcut key hint, or null if not set.
+   */
+  public String getShortcut() {
+    return shortcut;
+  }
+
+  /**
+   * Checks if the item is marked as a favorite.
+   *
+   * @return True if the item is marked as a favorite, otherwise false.
+   */
+  public boolean isFavorite() {
+    return favorite;
+  }
+
+  /**
+   * Gets the children items of the current item. Returns an empty list if there are no children.
+   *
+   * @return An unmodifiable list of child {@code SideMenuItem}s.
+   */
+  public List<SideMenuItem> getChildren() {
+    return Collections.unmodifiableList(children);
+  }
+
+  /**
+   * Sets the unique identifier for the item.
+   *
+   * @param id The non-null unique identifier to set.
+   * @return This {@code SideMenuItem} instance for method chaining.
+   * @throws NullPointerException if id is null.
+   */
+  public SideMenuItem setId(String id) {
+    Objects.requireNonNull(id, ID_NULL_ERROR_MESSAGE);
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * Sets the icon associated with the item.
+   *
+   * @param icon The icon string (URL, data URL, icon name, or pool:name) to set. Can be null.
+   * @return This {@code SideMenuItem} instance for method chaining.
+   */
+  public SideMenuItem setIcon(String icon) {
+    this.icon = icon;
+    return this;
+  }
+
+  /**
+   * Sets the display text or label for the item.
+   *
+   * @param label The non-null display label to set.
+   * @return This {@code SideMenuItem} instance for method chaining.
+   * @throws NullPointerException if label is null.
+   */
+  public SideMenuItem setLabel(String label) {
+    Objects.requireNonNull(label, LABEL_NULL_ERROR_MESSAGE);
+    this.label = label;
+    return this;
+  }
+
+  /**
+   * Sets the URL or link associated with the item.
+   *
+   * @param link The URL or link to set. Can be null.
+   * @return This {@code SideMenuItem} instance for method chaining.
+   */
+  public SideMenuItem setLink(String link) {
+    this.link = link;
+    return this;
+  }
+
+  /**
+   * Sets whether the link should be opened in a new tab.
+   *
+   * @param newTab True if the link should be opened in a new tab, false otherwise.
+   * @return This {@code SideMenuItem} instance for method chaining.
+   */
+  public SideMenuItem setNewTab(boolean newTab) {
+    this.newTab = newTab;
+    return this;
+  }
+
+  /**
+   * Sets the shortcut key hint associated with the item.
+   *
+   * @param shortcut The shortcut key hint to set. Can be null.
+   * @return This {@code SideMenuItem} instance for method chaining.
+   */
+  public SideMenuItem setShortcut(String shortcut) {
+    this.shortcut = shortcut;
+    return this;
+  }
+
+  /**
+   * Sets whether the item is marked as a favorite.
+   *
+   * @param favorite True to mark as favorite, false otherwise.
+   * @return This {@code SideMenuItem} instance for method chaining.
+   */
+  public SideMenuItem setFavorite(boolean favorite) {
+    this.favorite = favorite;
+    return this;
+  }
+
+  /**
+   * Sets the children items of the current item. The provided list will replace any existing
+   * children.
+   *
+   * @param children The list of child {@code SideMenuItem}s to set. If null, children will be set
+   *     to an empty list.
+   * @return This {@code SideMenuItem} instance for method chaining.
+   */
+  public SideMenuItem setChildren(List<SideMenuItem> children) {
+    Objects.requireNonNull(children, "Children list cannot be null");
+    this.children = new ArrayList<>(children);
+    return this;
+  }
+
+  /**
+   * Creates a new builder instance to construct a {@code SideMenuItem}. This is the recommended way
+   * to create items.
+   *
+   * @return An {@link IId} instance to start the building process.
+   */
+  public static IId builder() {
+    return new Builder();
+  }
+
+  /** Enforces setting the ID first. */
+  public interface IId {
+    /**
+     * Sets the mandatory unique identifier for the item.
+     *
+     * @param id The unique identifier. Cannot be null.
+     * @return The next step in the builder process (setting the label).
+     */
+    ILabel id(String id);
+  }
+
+  /** Enforces setting the label second. */
+  public interface ILabel {
+    /**
+     * Sets the mandatory display label for the item.
+     *
+     * @param label The text displayed to the user. Cannot be null.
+     * @return The next step in the builder process (setting optional attributes).
+     */
+    IBuild label(String label);
+  }
+
+  /** Allows setting optional properties and building the item. */
+  public interface IBuild extends IId, ILabel {
+    /**
+     * Sets the optional icon for the item.
+     *
+     * @param icon The icon string (URL, data URL, icon name, or pool:name).
+     * @return This builder instance for further configuration.
+     */
+    IBuild icon(String icon);
+
+    /**
+     * Sets the optional URL or link for the item.
+     *
+     * @param link The URL or link.
+     * @return This builder instance for further configuration.
+     */
+    IBuild link(String link);
+
+    /**
+     * Sets whether the link should open in a new tab. Defaults to false if not called.
+     *
+     * @param newTab True to open in a new tab, false otherwise.
+     * @return This builder instance for further configuration.
+     */
+    IBuild newTab(boolean newTab);
+
+    /**
+     * Sets the optional shortcut key hint for the item.
+     *
+     * @param shortcut The shortcut hint text.
+     * @return This builder instance for further configuration.
+     */
+    IBuild shortcut(String shortcut);
+
+    /**
+     * Sets whether the item is marked as a favorite. Defaults to false if not called.
+     *
+     * @param favorite True to mark as favorite, false otherwise.
+     * @return This builder instance for further configuration.
+     */
+    IBuild favorite(boolean favorite);
+
+    /**
+     * Sets the child items for this item, creating a nested level. If not called, the item will
+     * have no children.
+     *
+     * @param children A list of {@code SideMenuItem}s.
+     * @return This builder instance for further configuration.
+     */
+    IBuild children(List<SideMenuItem> children);
+
+    /**
+     * Constructs the final {@code SideMenuItem} instance.
+     *
+     * @return The fully configured {@code SideMenuItem}.
+     */
+    SideMenuItem build();
+  }
+
+  /** Private implementation of the builder steps. */
+  private static class Builder implements IId, ILabel, IBuild {
+    private String id;
+    private String label;
+    private String icon;
+    private String link;
+    private boolean newTab = false;
+    private String shortcut;
+    private boolean favorite = false;
+    private List<SideMenuItem> children;
+
+    private Builder() {}
+
+    @Override
+    public ILabel id(String id) {
+      Objects.requireNonNull(id, ID_NULL_ERROR_MESSAGE);
+      this.id = id;
+      return this;
+    }
+
+    @Override
+    public IBuild label(String label) {
+      Objects.requireNonNull(label, LABEL_NULL_ERROR_MESSAGE);
+      this.label = label;
+      return this;
+    }
+
+    @Override
+    public IBuild icon(String icon) {
+      this.icon = icon;
+      return this;
+    }
+
+    @Override
+    public IBuild link(String link) {
+      this.link = link;
+      return this;
+    }
+
+    @Override
+    public IBuild newTab(boolean newTab) {
+      this.newTab = newTab;
+      return this;
+    }
+
+    @Override
+    public IBuild shortcut(String shortcut) {
+      this.shortcut = shortcut;
+      return this;
+    }
+
+    @Override
+    public IBuild favorite(boolean favorite) {
+      this.favorite = favorite;
+      return this;
+    }
+
+    @Override
+    public IBuild children(List<SideMenuItem> children) {
+      this.children = (children != null) ? new ArrayList<>(children) : null;
+      return this;
+    }
+
+    @Override
+    public SideMenuItem build() {
+      return new SideMenuItem(this);
+    }
+  }
+}

--- a/webforj-addons-components/webforj-side-menu/src/test/java/com/webforj/addons/components/sidemenu/SideMenuItemTest.java
+++ b/webforj-addons-components/webforj-side-menu/src/test/java/com/webforj/addons/components/sidemenu/SideMenuItemTest.java
@@ -1,0 +1,290 @@
+package com.webforj.addons.components.sidemenu;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SideMenuItem Tests")
+class SideMenuItemTest {
+
+  private static final String DEFAULT_ID = "item-1";
+  private static final String DEFAULT_LABEL = "Item 1";
+
+  @Nested
+  @DisplayName("Builder Tests")
+  class BuilderTests {
+
+    @Test
+    @DisplayName("should build item with only mandatory fields")
+    void buildWithMandatoryFields() {
+      SideMenuItem item = SideMenuItem.builder().id(DEFAULT_ID).label(DEFAULT_LABEL).build();
+
+      assertNotNull(item);
+      assertEquals(DEFAULT_ID, item.getId());
+      assertEquals(DEFAULT_LABEL, item.getLabel());
+      assertNull(item.getIcon());
+      assertNull(item.getLink());
+      assertFalse(item.isNewTab());
+      assertNull(item.getShortcut());
+      assertFalse(item.isFavorite());
+      assertNotNull(item.getChildren());
+      assertTrue(item.getChildren().isEmpty());
+    }
+
+    @Test
+    @DisplayName("should build item with all optional fields")
+    void buildWithAllFields() {
+      final var icon = "feather:home";
+      final var link = "/home";
+      final var newTab = true;
+      final var shortcut = "Ctrl+H";
+      final var favorite = true;
+      final var child1 = SideMenuItem.builder().id("child-1").label("Child 1").build();
+      final var children = Collections.singletonList(child1);
+
+      final var item =
+          SideMenuItem.builder()
+              .id(DEFAULT_ID)
+              .label(DEFAULT_LABEL)
+              .icon(icon)
+              .link(link)
+              .newTab(newTab)
+              .shortcut(shortcut)
+              .favorite(favorite)
+              .children(children)
+              .build();
+
+      assertNotNull(item);
+      assertEquals(DEFAULT_ID, item.getId());
+      assertEquals(DEFAULT_LABEL, item.getLabel());
+      assertEquals(icon, item.getIcon());
+      assertEquals(link, item.getLink());
+      assertEquals(newTab, item.isNewTab());
+      assertEquals(shortcut, item.getShortcut());
+      assertEquals(favorite, item.isFavorite());
+      assertNotNull(item.getChildren());
+      assertEquals(1, item.getChildren().size());
+      assertEquals(child1, item.getChildren().get(0));
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException when mandatory ID is null")
+    void buildWithNullId() {
+      final var builder = SideMenuItem.builder();
+      final var exception =
+          assertThrows(
+              NullPointerException.class,
+              () -> {
+                builder.id(null);
+              });
+      assertEquals("ID cannot be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException when mandatory label is null")
+    void buildWithNullLabel() {
+      final var builderStep1 = SideMenuItem.builder();
+      final var builderStep2 = builderStep1.id(DEFAULT_ID);
+      final var exception =
+          assertThrows(
+              NullPointerException.class,
+              () -> {
+                builderStep2.label(null);
+              });
+      assertEquals("Label cannot be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("should handle null children list by defaulting to empty")
+    void buildWithNullChildren() {
+      final var item =
+          SideMenuItem.builder().id(DEFAULT_ID).label(DEFAULT_LABEL).children(null).build();
+
+      assertNotNull(item.getChildren());
+      assertTrue(item.getChildren().isEmpty());
+    }
+
+    @Test
+    @DisplayName("should handle empty children list")
+    void buildWithEmptyChildren() {
+      final var item =
+          SideMenuItem.builder()
+              .id(DEFAULT_ID)
+              .label(DEFAULT_LABEL)
+              .children(new ArrayList<>())
+              .build();
+
+      assertNotNull(item.getChildren());
+      assertTrue(item.getChildren().isEmpty());
+    }
+
+    @Test
+    @DisplayName("should create internal copy when building with children list")
+    void buildWithChildrenCreatesCopy() {
+      final var child1 = SideMenuItem.builder().id("c1").label("C1").build();
+      final var originalChildren = new ArrayList<>(Collections.singletonList(child1));
+
+      final var item =
+          SideMenuItem.builder()
+              .id(DEFAULT_ID)
+              .label(DEFAULT_LABEL)
+              .children(originalChildren)
+              .build();
+
+      originalChildren.add(SideMenuItem.builder().id("c2").label("C2").build());
+
+      assertNotNull(item.getChildren());
+      assertEquals(1, item.getChildren().size());
+      assertEquals("c1", item.getChildren().get(0).getId());
+    }
+  }
+
+  @Nested
+  @DisplayName("Copy Constructor Tests")
+  class CopyConstructorTests {
+
+    private SideMenuItem sourceItem;
+
+    @BeforeEach
+    void setUpSourceItem() {
+      final var child = SideMenuItem.builder().id("child-1").label("Child 1").build();
+      sourceItem =
+          SideMenuItem.builder()
+              .id(DEFAULT_ID)
+              .label(DEFAULT_LABEL)
+              .icon("feather:copy")
+              .link("/copy")
+              .newTab(true)
+              .shortcut("Ctrl+C")
+              .favorite(true)
+              .children(Collections.singletonList(child))
+              .build();
+    }
+
+    @Test
+    @DisplayName("should correctly copy all properties from source item")
+    void copyAllProperties() {
+      final var copiedItem = new SideMenuItem(sourceItem);
+
+      assertEquals(sourceItem.getId(), copiedItem.getId());
+      assertEquals(sourceItem.getLabel(), copiedItem.getLabel());
+      assertEquals(sourceItem.getIcon(), copiedItem.getIcon());
+      assertEquals(sourceItem.getLink(), copiedItem.getLink());
+      assertEquals(sourceItem.isNewTab(), copiedItem.isNewTab());
+      assertEquals(sourceItem.getShortcut(), copiedItem.getShortcut());
+      assertEquals(sourceItem.isFavorite(), copiedItem.isFavorite());
+      assertNotNull(copiedItem.getChildren());
+      assertEquals(sourceItem.getChildren().size(), copiedItem.getChildren().size());
+      assertEquals(
+          sourceItem.getChildren().get(0).getId(), copiedItem.getChildren().get(0).getId());
+    }
+
+    @Test
+    @DisplayName("should create a distinct object instance")
+    void copyCreatesDistinctObject() {
+      final var copiedItem = new SideMenuItem(sourceItem);
+      assertNotSame(sourceItem, copiedItem, "Copied object should be a different instance");
+    }
+
+    @Test
+    @DisplayName("should create a distinct children list instance")
+    void copyCreatesDistinctChildrenList() {
+      assertFalse(
+          sourceItem.getChildren().isEmpty(), "Source item must have children for this test");
+
+      final var copiedItem = new SideMenuItem(sourceItem);
+
+      assertNotSame(
+          sourceItem.getChildren(),
+          copiedItem.getChildren(),
+          "Copied item's children list should be a different instance");
+    }
+
+    @Test
+    @DisplayName("should correctly copy item with only mandatory fields")
+    void copyMinimalItem() {
+      final var minimalSource =
+          SideMenuItem.builder().id("minimal-id").label("Minimal Label").build();
+      final var copiedItem = new SideMenuItem(minimalSource);
+
+      assertEquals("minimal-id", copiedItem.getId());
+      assertEquals("Minimal Label", copiedItem.getLabel());
+      assertNull(copiedItem.getIcon());
+      assertNull(copiedItem.getLink());
+      assertFalse(copiedItem.isNewTab());
+      assertNull(copiedItem.getShortcut());
+      assertFalse(copiedItem.isFavorite());
+      assertNotNull(copiedItem.getChildren());
+      assertTrue(copiedItem.getChildren().isEmpty());
+    }
+  }
+
+  @Nested
+  @DisplayName("Setter Tests")
+  class SetterTests {
+
+    private SideMenuItem item;
+
+    @BeforeEach
+    void setUp() {
+      item = SideMenuItem.builder().id(DEFAULT_ID).label(DEFAULT_LABEL).build();
+    }
+
+    @Test
+    @DisplayName("setId() should throw NullPointerException for null ID")
+    void setIdNull() {
+      final var exception =
+          assertThrows(
+              NullPointerException.class,
+              () -> {
+                item.setId(null);
+              });
+      assertEquals("ID cannot be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("setLabel() should throw NullPointerException for null label")
+    void setLabelNull() {
+      final var exception =
+          assertThrows(
+              NullPointerException.class,
+              () -> {
+                item.setLabel(null);
+              });
+      assertEquals("Label cannot be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("setChildren() should throw NullPointerException for null list")
+    void setChildrenNull() {
+      final var exception =
+          assertThrows(
+              NullPointerException.class,
+              () -> {
+                item.setChildren(null);
+              });
+      assertEquals("Children list cannot be null", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("setChildren() should create an internal copy of the provided list")
+    void setChildrenCreatesCopy() {
+      final var child1 = SideMenuItem.builder().id("c1").label("C1").build();
+      final var originalChildren = new ArrayList<>(Collections.singletonList(child1));
+
+      item.setChildren(originalChildren);
+
+      originalChildren.add(SideMenuItem.builder().id("c2").label("C2").build());
+
+      assertNotNull(item.getChildren());
+      assertEquals(1, item.getChildren().size());
+      assertEquals("c1", item.getChildren().get(0).getId());
+      assertNotSame(originalChildren, item.getChildren());
+    }
+  }
+}

--- a/webforj-addons-components/webforj-side-menu/src/test/java/com/webforj/addons/components/sidemenu/SideMenuTest.java
+++ b/webforj-addons-components/webforj-side-menu/src/test/java/com/webforj/addons/components/sidemenu/SideMenuTest.java
@@ -1,0 +1,525 @@
+package com.webforj.addons.components.sidemenu;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("SideMenu Item Manipulation Tests")
+@ExtendWith(MockitoExtension.class)
+class SideMenuTest {
+
+  @Spy SideMenu sideMenu = new SideMenu();
+
+  @Captor ArgumentCaptor<List<SideMenuItem>> itemsListCaptor;
+
+  private SideMenuItem item1;
+  private SideMenuItem item2;
+  private SideMenuItem item3;
+  private SideMenuItem child11;
+  private SideMenuItem grandchild111;
+
+  @BeforeEach
+  void setUp() {
+    item1 = SideMenuItem.builder().id("item-1").label("Item 1").build();
+    child11 = SideMenuItem.builder().id("child-1-1").label("Child 1.1").build();
+    grandchild111 = SideMenuItem.builder().id("grandchild-1-1-1").label("Grandchild 1.1.1").build();
+    item1 =
+        new SideMenuItem(item1)
+            .setChildren(
+                Collections.singletonList(
+                    new SideMenuItem(child11)
+                        .setChildren(Collections.singletonList(grandchild111))));
+    item2 = SideMenuItem.builder().id("item-2").label("Item 2").build();
+    item3 = SideMenuItem.builder().id("item-3").label("Item 3").build();
+
+    sideMenu.setItems(new ArrayList<>(Arrays.asList(item1, item2)));
+    clearInvocations(sideMenu);
+  }
+
+  private Optional<SideMenuItem> findInList(List<SideMenuItem> items, String id) {
+    if (items == null) {
+      return Optional.empty();
+    }
+    for (SideMenuItem item : items) {
+      if (item.getId().equals(id)) {
+        return Optional.of(item);
+      }
+      final var foundInChildren = findInList(item.getChildren(), id);
+      if (foundInChildren.isPresent()) {
+        return foundInChildren;
+      }
+    }
+    return Optional.empty();
+  }
+
+  @Nested
+  @DisplayName("addItem(SideMenuItem item)")
+  class AddSingleItemTests {
+
+    @Test
+    @DisplayName("should add item to an empty list")
+    void addItemToEmptyList() {
+      sideMenu.setItems(new ArrayList<>());
+      clearInvocations(sideMenu);
+
+      final var returned = sideMenu.addItem(item3);
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      List<SideMenuItem> capturedList = itemsListCaptor.getValue();
+      assertEquals(1, capturedList.size());
+      assertEquals(item3, capturedList.get(0));
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should add item to the end of an existing list")
+    void addItemToExistingList() {
+      sideMenu.addItem(item3);
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(3, capturedList.size());
+      assertEquals(item1, capturedList.get(0));
+      assertEquals(item2, capturedList.get(1));
+      assertEquals(item3, capturedList.get(2));
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException when adding null item")
+    void addNullItem() {
+      assertThrows(NullPointerException.class, () -> sideMenu.addItem(null), "Item cannot be null");
+      verify(sideMenu, never()).setItems(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("addItem(String parentId, SideMenuItem childItem)")
+  class AddChildItemTests {
+
+    private SideMenuItem newChild;
+
+    @BeforeEach
+    void setupChild() {
+      newChild = SideMenuItem.builder().id("new-child").label("New Child").build();
+    }
+
+    @Test
+    @DisplayName("should add child to a top-level parent")
+    void addChildToTopLevel() {
+      final var returned = sideMenu.addItem("item-1", newChild);
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+
+      assertEquals(2, capturedList.size(), "Top-level size should remain the same");
+
+      final var updatedParentOpt = findInList(capturedList, "item-1");
+      assertTrue(updatedParentOpt.isPresent(), "Parent item-1 should still exist");
+      final var updatedParent = updatedParentOpt.get();
+
+      assertEquals(
+          2, updatedParent.getChildren().size(), "Parent item-1 should have 2 children now");
+      assertTrue(
+          findInList(updatedParent.getChildren(), "child-1-1").isPresent(),
+          "Original child should exist");
+      assertTrue(
+          findInList(updatedParent.getChildren(), "new-child").isPresent(),
+          "New child should exist");
+
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should add child to a nested parent")
+    void addChildToNestedParent() {
+      final var returned = sideMenu.addItem("child-1-1", newChild);
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+
+      Optional<SideMenuItem> topParentOpt = findInList(capturedList, "item-1");
+      assertTrue(topParentOpt.isPresent());
+      SideMenuItem topParent = topParentOpt.get();
+      assertNotSame(item1, topParent, "Top parent should be recreated due to child modification");
+
+      Optional<SideMenuItem> nestedParentOpt = findInList(topParent.getChildren(), "child-1-1");
+      assertTrue(nestedParentOpt.isPresent());
+      SideMenuItem nestedParent = nestedParentOpt.get();
+      assertNotSame(child11, nestedParent, "Nested parent should be recreated");
+
+      assertEquals(
+          2, nestedParent.getChildren().size(), "Nested parent should have 2 children now");
+      assertTrue(
+          findInList(nestedParent.getChildren(), "grandchild-1-1-1").isPresent(),
+          "Original grandchild should exist");
+      assertTrue(
+          findInList(nestedParent.getChildren(), "new-child").isPresent(),
+          "New child should exist");
+
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should throw IllegalArgumentException if parentId not found")
+    void addChildToNonExistentParent() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> sideMenu.addItem("non-existent-id", newChild),
+          "Parent item with ID 'non-existent-id' not found.");
+      verify(sideMenu, never()).setItems(any());
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException if parentId is null")
+    void addChildWithNullParentId() {
+      assertThrows(
+          NullPointerException.class,
+          () -> sideMenu.addItem(null, newChild),
+          "Parent ID cannot be null");
+      verify(sideMenu, never()).setItems(any());
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException if childItem is null")
+    void addChildWithNullChildItem() {
+      assertThrows(
+          NullPointerException.class,
+          () -> sideMenu.addItem("item-1", null),
+          "Child item cannot be null");
+      verify(sideMenu, never()).setItems(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("addItems(SideMenuItem... items)")
+  class AddVarArgsItemsTests {
+
+    @Test
+    @DisplayName("should add multiple items to an empty list")
+    void addItemsToEmptyList() {
+      sideMenu.setItems(new ArrayList<>());
+      clearInvocations(sideMenu);
+
+      final var returned = sideMenu.addItems(item1, item2);
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(2, capturedList.size());
+      assertEquals(item1, capturedList.get(0));
+      assertEquals(item2, capturedList.get(1));
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should add multiple items to an existing list")
+    void addItemsToExistingList() {
+      final var item4 = SideMenuItem.builder().id("item-4").label("Item 4").build();
+      final var returned = sideMenu.addItems(item3, item4);
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(4, capturedList.size());
+      assertEquals(item1, capturedList.get(0));
+      assertEquals(item2, capturedList.get(1));
+      assertEquals(item3, capturedList.get(2));
+      assertEquals(item4, capturedList.get(3));
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should do nothing when adding empty varargs")
+    void addEmptyVarArgs() {
+      final var returned = sideMenu.addItems();
+      verify(sideMenu, never()).setItems(any());
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException if items array is null")
+    void addNullVarArgsArray() {
+      assertThrows(
+          NullPointerException.class,
+          () -> sideMenu.addItems((SideMenuItem[]) null),
+          "Items array cannot be null");
+      verify(sideMenu, never()).setItems(any());
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException if items array contains null")
+    void addVarArgsWithNullElement() {
+      assertThrows(
+          NullPointerException.class,
+          () -> sideMenu.addItems(item1, null, item2),
+          "Items array cannot contain null elements");
+      verify(sideMenu, never()).setItems(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("addItems(Collection<SideMenuItem> items)")
+  class AddCollectionItemsTests {
+
+    @Test
+    @DisplayName("should add collection items to an empty list")
+    void addCollectionToEmptyList() {
+      sideMenu.setItems(new ArrayList<>());
+      clearInvocations(sideMenu);
+      final var itemsToAdd = Arrays.asList(item1, item2);
+
+      final var returned = sideMenu.addItems(itemsToAdd);
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(2, capturedList.size());
+      assertEquals(item1, capturedList.get(0));
+      assertEquals(item2, capturedList.get(1));
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should add collection items to an existing list")
+    void addCollectionToExistingList() {
+      final var item4 = SideMenuItem.builder().id("item-4").label("Item 4").build();
+      final var itemsToAdd = Arrays.asList(item3, item4);
+      final var returned = sideMenu.addItems(itemsToAdd);
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(4, capturedList.size());
+      assertEquals(item1, capturedList.get(0));
+      assertEquals(item2, capturedList.get(1));
+      assertEquals(item3, capturedList.get(2));
+      assertEquals(item4, capturedList.get(3));
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should do nothing when adding empty collection")
+    void addEmptyCollection() {
+      final var returned = sideMenu.addItems(new ArrayList<>());
+      verify(sideMenu, never()).setItems(any());
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException if collection is null")
+    void addNullCollection() {
+      assertThrows(
+          NullPointerException.class,
+          () -> sideMenu.addItems((Collection<SideMenuItem>) null),
+          "Items collection cannot be null");
+      verify(sideMenu, never()).setItems(any());
+    }
+
+    @Test
+    @DisplayName("should throw NullPointerException if collection contains null")
+    void addCollectionWithNullElement() {
+      final var itemsToAdd = Arrays.asList(item1, null, item2);
+      assertThrows(
+          NullPointerException.class,
+          () -> sideMenu.addItems(itemsToAdd),
+          "Items collection cannot contain null elements");
+      verify(sideMenu, never()).setItems(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("removeItem(SideMenuItem item)")
+  class RemoveItemObjectTests {
+
+    @Test
+    @DisplayName("should call removeItemById with correct ID")
+    void removeItemDelegatesCorrectly() {
+      final var returned = sideMenu.removeItem(item1);
+
+      verify(sideMenu).removeItemById(item1.getId());
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should do nothing if item is null")
+    void removeNullItemObject() {
+      final var returned = sideMenu.removeItem(null);
+      verify(sideMenu, never()).removeItemById(any());
+      verify(sideMenu, never()).setItems(any());
+      assertSame(sideMenu, returned);
+    }
+  }
+
+  @Nested
+  @DisplayName("removeItemById(String itemId)")
+  class RemoveItemIdTests {
+
+    @Test
+    @DisplayName("should remove top-level item")
+    void removeTopLevelItem() {
+      final var returned = sideMenu.removeItemById("item-2");
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertEquals(1, capturedList.size());
+      assertEquals("item-1", capturedList.get(0).getId());
+      assertSame(item1, capturedList.get(0), "Item 1 should be original instance");
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should remove nested item")
+    void removeNestedItem() {
+      final var returned = sideMenu.removeItemById("child-1-1");
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+
+      assertEquals(2, capturedList.size());
+
+      Optional<SideMenuItem> topParentOpt = findInList(capturedList, "item-1");
+      assertTrue(topParentOpt.isPresent());
+      SideMenuItem topParent = topParentOpt.get();
+      assertNotSame(item1, topParent, "Top parent should be recreated");
+
+      assertEquals(0, topParent.getChildren().size(), "Item 1 should have no children now");
+
+      Optional<SideMenuItem> otherItemOpt = findInList(capturedList, "item-2");
+      assertTrue(otherItemOpt.isPresent());
+      assertSame(item2, otherItemOpt.get(), "Item 2 should be original instance");
+
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should remove deeply nested item")
+    void removeDeeplyNestedItem() {
+      final var returned = sideMenu.removeItemById("grandchild-1-1-1");
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+
+      assertEquals(2, capturedList.size());
+
+      Optional<SideMenuItem> topParentOpt = findInList(capturedList, "item-1");
+      assertTrue(topParentOpt.isPresent());
+      SideMenuItem topParent = topParentOpt.get();
+      assertNotSame(item1, topParent, "Top parent should be recreated");
+
+      Optional<SideMenuItem> nestedParentOpt = findInList(topParent.getChildren(), "child-1-1");
+      assertTrue(nestedParentOpt.isPresent());
+      SideMenuItem nestedParent = nestedParentOpt.get();
+      assertNotSame(child11, nestedParent, "Nested parent should be recreated");
+
+      assertEquals(
+          0, nestedParent.getChildren().size(), "Nested parent should have no children now");
+
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should do nothing if item ID not found")
+    void removeNonExistentItem() {
+      final var returned = sideMenu.removeItemById("non-existent-id");
+      verify(sideMenu, never()).setItems(any());
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should do nothing if item ID is null")
+    void removeNullItemId() {
+      final var returned = sideMenu.removeItemById(null);
+      verify(sideMenu, never()).setItems(any());
+      assertSame(sideMenu, returned);
+    }
+  }
+
+  @Nested
+  @DisplayName("findItemById(String itemId)")
+  class FindItemByIdTests {
+
+    @Test
+    @DisplayName("should find a top-level item")
+    void findTopLevelItem() {
+      Optional<SideMenuItem> found = sideMenu.findItemById("item-2");
+      assertTrue(found.isPresent(), "Item 2 should be found");
+      assertEquals("item-2", found.get().getId());
+      assertSame(item2, found.get(), "Should return the correct instance");
+    }
+
+    @Test
+    @DisplayName("should find a nested item")
+    void findNestedItem() {
+      Optional<SideMenuItem> found = sideMenu.findItemById("child-1-1");
+      assertTrue(found.isPresent(), "Child 1.1 should be found");
+      assertEquals("child-1-1", found.get().getId());
+    }
+
+    @Test
+    @DisplayName("should find a deeply nested item")
+    void findDeeplyNestedItem() {
+      Optional<SideMenuItem> found = sideMenu.findItemById("grandchild-1-1-1");
+      assertTrue(found.isPresent(), "Grandchild 1.1.1 should be found");
+      assertEquals("grandchild-1-1-1", found.get().getId());
+    }
+
+    @Test
+    @DisplayName("should return empty Optional if ID not found")
+    void findNonExistentItem() {
+      Optional<SideMenuItem> found = sideMenu.findItemById("non-existent-id");
+      assertFalse(found.isPresent(), "Should not find non-existent ID");
+    }
+
+    @Test
+    @DisplayName("should return empty Optional if ID is null")
+    void findNullId() {
+      Optional<SideMenuItem> found = sideMenu.findItemById(null);
+      assertFalse(found.isPresent(), "Should return empty for null ID");
+    }
+
+    @Test
+    @DisplayName("should return empty Optional if items list is empty")
+    void findInEmptyList() {
+      sideMenu.setItems(new ArrayList<>());
+      Optional<SideMenuItem> found = sideMenu.findItemById("item-1");
+      assertFalse(found.isPresent(), "Should not find anything in an empty list");
+    }
+  }
+
+  @Nested
+  @DisplayName("clearItems()")
+  class ClearItemsTests {
+
+    @Test
+    @DisplayName("should set items to an empty list when clearing non-empty list")
+    void clearNonEmptyList() {
+      final var returned = sideMenu.clearItems();
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertNotNull(capturedList);
+      assertTrue(capturedList.isEmpty());
+      assertSame(sideMenu, returned);
+    }
+
+    @Test
+    @DisplayName("should set items to an empty list when clearing an empty list")
+    void clearEmptyList() {
+      sideMenu.setItems(new ArrayList<>());
+      clearInvocations(sideMenu);
+
+      final var returned = sideMenu.clearItems();
+
+      verify(sideMenu).setItems(itemsListCaptor.capture());
+      final var capturedList = itemsListCaptor.getValue();
+      assertNotNull(capturedList);
+      assertTrue(capturedList.isEmpty());
+      assertSame(sideMenu, returned);
+    }
+  }
+}


### PR DESCRIPTION
### Description
The previous API for managing items within the `SideMenu` component relied solely on the `setItems(List<Item> items)` method. This required developers to manually fetch, modify, and then set the entire list, even for simple additions or removals. This approach was cumbersome, less intuitive, and potentially error-prone.

The goal of this change is to provide a more seamless, flexible, and developer-friendly API for interacting with the component's items, making common operations much simpler.