### PR TITLE
chore: add configuration for automatic release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+changelog:
+  exclude:
+    labels:
+      - 'skip-changelog'
+      - 'type: dependencies'
+
+    authors:
+      - 'dependabot[bot]'
+
+  categories:
+    - title: '💥 Breaking Changes'
+      labels:
+        - 'type: breaking'
+
+    - title: '🚀 New Features and Enhancements'
+      labels:
+        - 'type: feature request'
+        - 'type: enhancement'
+
+    - title: '🐛 Bug Fixes'
+      labels:
+        - 'type: bug'
+        - 'type: fix'
+
+    - title: '⚙️ Other Changes'
+      labels:
+        - 'type: chore'
+        - 'type: refactor'
+        - 'type: test'
+        - 'area: build'
+        - 'type: documentation'

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -11,16 +11,6 @@ on:
         type: boolean
         required: false
         default: false
-      prerelease:
-        description: "Is pre-release?"
-        type: boolean
-        required: false
-        default: false
-      draft:
-        description: "Is draft?"
-        type: boolean
-        required: false
-        default: false
 
 jobs:
   bumpVersion:
@@ -56,6 +46,4 @@ jobs:
           generateReleaseNotes: true
           tag: ${{ github.event.inputs.version }}
           name: Release v${{ github.event.inputs.version }}
-          draft: ${{ github.event.inputs.draft }}
-          prerelease: ${{ github.event.inputs.prerelease }}
-          makeLatest: ${{ github.event.inputs.prerelease == 'false' }}
+          makeLatest: true


### PR DESCRIPTION
### Description
This PR introduces the `.github/release.yml` configuration file to enable and customize GitHub's automatic release notes generation feature for the `webforj-addons` repository.

#### Why
* Automates the often time-consuming process of compiling release notes.
* Ensures a consistent format and structure for release communications.
* Helps accurately highlight significant changes (breaking changes, features, fixes) for users.
* Reduces the chance of accidentally omitting merged PRs from release notes.
* Allows for intentional exclusion of less relevant changes (e.g., automated dependency updates, internal chores).