### PR TITLE
feat: adding a favorite change event for SideMenu component

### DIFF
--- a/webforj-addons-components/webforj-side-menu/src/main/java/com/webforj/addons/components/sidemenu/SideMenu.java
+++ b/webforj-addons-components/webforj-side-menu/src/main/java/com/webforj/addons/components/sidemenu/SideMenu.java
@@ -3,6 +3,7 @@ package com.webforj.addons.components.sidemenu;
 import com.google.gson.annotations.SerializedName;
 import com.webforj.PendingResult;
 import com.webforj.addons.components.sidemenu.events.ChangedEvent;
+import com.webforj.addons.components.sidemenu.events.FavoriteChangedEvent;
 import com.webforj.addons.components.sidemenu.events.ItemClickedEvent;
 import com.webforj.addons.components.sidemenu.events.SearchedEvent;
 import com.webforj.addons.constant.GlobalConstants;
@@ -152,6 +153,18 @@ public class SideMenu extends ElementComposite
   public ListenerRegistration<SearchedEvent> addSearchedListener(
       EventListener<SearchedEvent> listener) {
     return this.addEventListener(SearchedEvent.class, listener);
+  }
+
+  /**
+   * Adds a listener for the favorite changed event, which is triggered when an item's favorite
+   * status is changed.
+   *
+   * @param listener The event listener to add.
+   * @return A registration object that can be used to unregister the listener if needed.
+   */
+  public ListenerRegistration<FavoriteChangedEvent> addFavoriteChangedListener(
+      EventListener<FavoriteChangedEvent> listener) {
+    return this.addEventListener(FavoriteChangedEvent.class, listener);
   }
 
   /**

--- a/webforj-addons-components/webforj-side-menu/src/main/java/com/webforj/addons/components/sidemenu/events/ChangedEvent.java
+++ b/webforj-addons-components/webforj-side-menu/src/main/java/com/webforj/addons/components/sidemenu/events/ChangedEvent.java
@@ -1,8 +1,8 @@
 package com.webforj.addons.components.sidemenu.events;
 
 import com.google.gson.Gson;
-import com.webforj.addons.components.sidemenu.Item;
 import com.webforj.addons.components.sidemenu.SideMenu;
+import com.webforj.addons.components.sidemenu.SideMenuItem;
 import com.webforj.component.element.annotation.EventName;
 import com.webforj.component.element.annotation.EventOptions;
 import com.webforj.component.event.ComponentEvent;
@@ -38,10 +38,10 @@ public class ChangedEvent extends ComponentEvent<SideMenu> {
    *
    * @return The new selected item.
    */
-  public Item getSelectedItem() {
+  public SideMenuItem getSelectedItem() {
     final var gson = new Gson();
     final var itemJson = gson.toJson(this.getEventMap().get("selected"));
-    return gson.fromJson(itemJson, Item.class);
+    return gson.fromJson(itemJson, SideMenuItem.class);
   }
 
   /**
@@ -49,21 +49,21 @@ public class ChangedEvent extends ComponentEvent<SideMenu> {
    *
    * <p>In the context of this application, a "deselected item" may not always exist. For example,
    * during the first selection, there is no prior item to deselect. To accommodate this, the method
-   * returns an {@code Optional<Item>} instead of {@code null}. This makes it explicit to the caller
-   * that the absence of a value is a normal, expected state and encourages proper handling of such
-   * cases.
+   * returns an {@code Optional<SideMenuItem>} instead of {@code null}. This makes it explicit to
+   * the caller that the absence of a value is a normal, expected state and encourages proper
+   * handling of such cases.
    *
    * @return An {@code Optional} containing the deselected item if one exists, or an empty {@code
    *     Optional} otherwise.
    */
-  public Optional<Item> getDeselectedItem() {
+  public Optional<SideMenuItem> getDeselectedItem() {
     final var item = this.getEventMap().get("deselected");
     if (item == null) {
       return Optional.empty();
     }
     final var gson = new Gson();
     final var itemJson = gson.toJson(item);
-    final var deselectedItem = gson.fromJson(itemJson, Item.class);
+    final var deselectedItem = gson.fromJson(itemJson, SideMenuItem.class);
     return Optional.of(deselectedItem);
   }
 }

--- a/webforj-addons-components/webforj-side-menu/src/main/java/com/webforj/addons/components/sidemenu/events/FavoriteChangedEvent.java
+++ b/webforj-addons-components/webforj-side-menu/src/main/java/com/webforj/addons/components/sidemenu/events/FavoriteChangedEvent.java
@@ -9,29 +9,29 @@ import com.webforj.component.event.ComponentEvent;
 import java.util.Map;
 
 /**
- * Event fired when an item is clicked.
+ * Emitted when an item's favorite status is changed.
  *
- * @since 24.20
- * @author @ElyasSalar
+ * @author ElyasSalar
+ * @since 25.02
  */
-@EventName("dwc-item-clicked")
+@EventName("dwc-favorite-changed")
 @EventOptions(data = {@EventOptions.EventData(key = "item", exp = "event.detail")})
-public class ItemClickedEvent extends ComponentEvent<SideMenu> {
+public class FavoriteChangedEvent extends ComponentEvent<SideMenu> {
 
   /**
-   * Creates a new event {@code dwc-item-clicked} event.
+   * Creates a new favorite changed event.
    *
-   * @param component the component that fired the event
+   * @param component the SideMenu component
    * @param payload the event map
    */
-  public ItemClickedEvent(SideMenu component, Map<String, Object> payload) {
+  public FavoriteChangedEvent(SideMenu component, Map<String, Object> payload) {
     super(component, payload);
   }
 
   /**
-   * Gets the clicked item from the side menu.
+   * Gets the item whose favorite status was changed.
    *
-   * @return The clicked item.
+   * @return the item
    */
   public SideMenuItem getItem() {
     final var gson = new Gson();


### PR DESCRIPTION
### Summary
This PR adds a new `FavoriteChangedEvent` event to the `SideMenu` component that is fired whenever a user toggles the favorite status of a menu item. The event emits the complete `SideMenuItem` object directly, providing access to all item properties, including the updated favorite state.