### PR TITLE
fix: maven resource filtering for property replacement in webforJ addon components

### DIFF
--- a/webforj-addons-components/pom.xml
+++ b/webforj-addons-components/pom.xml
@@ -40,6 +40,68 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.14.0</version>
+          <configuration>
+            <compileSourceRoots>
+              <compileSourceRoot>${project.build.directory}/generated-sources/java</compileSourceRoot>
+            </compileSourceRoots>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+          <executions>
+            <execution>
+              <id>filter-sources</id>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <phase>generate-sources</phase>
+              <configuration>
+                <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
+                <resources>
+                  <resource>
+                    <directory>src/main/java</directory>
+                    <filtering>true</filtering>
+                    <includes>
+                      <include>**/*.java</include>
+                    </includes>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.6.1</version>
+          <executions>
+            <execution>
+              <id>add-generated-sources</id>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+              <phase>generate-sources</phase>
+              <configuration>
+                <sources>
+                  <source>${project.build.directory}/generated-sources/java</source>
+                </sources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
   <pluginRepositories>
     <pluginRepository>
       <releases>

--- a/webforj-addons-components/webforj-components-common/pom.xml
+++ b/webforj-addons-components/webforj-components-common/pom.xml
@@ -31,58 +31,11 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.0</version>
-        <configuration>
-          <compileSourceRoots>
-            <compileSourceRoot>${project.build.directory}/generated-sources/java</compileSourceRoot>
-          </compileSourceRoots>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
-        <executions>
-          <execution>
-            <id>filter-sources</id>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <phase>generate-sources</phase>
-            <configuration>
-              <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>src/main/java</directory>
-                  <filtering>true</filtering>
-                  <includes>
-                    <include>**/*GlobalConstants.java</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.6.1</version>
-        <executions>
-          <execution>
-            <id>add-generated-sources</id>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <phase>generate-sources</phase>
-            <configuration>
-              <sources>
-                <source>${project.build.directory}/generated-sources/java</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/webforj-addons-components/webforj-multi-select-combo/pom.xml
+++ b/webforj-addons-components/webforj-multi-select-combo/pom.xml
@@ -45,4 +45,17 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/webforj-addons-components/webforj-properties-panel/pom.xml
+++ b/webforj-addons-components/webforj-properties-panel/pom.xml
@@ -45,4 +45,17 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/webforj-addons-components/webforj-side-menu/pom.xml
+++ b/webforj-addons-components/webforj-side-menu/pom.xml
@@ -46,4 +46,17 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/webforj-addons-components/webforj-suggestion-edit/pom.xml
+++ b/webforj-addons-components/webforj-suggestion-edit/pom.xml
@@ -28,4 +28,17 @@
       <version>${project.parent.version}</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
### PR Description
This PR resolves an issue where the `${dwc.cdn.version}` property was not being replaced in component `@JavaScript` annotations during the Maven build process. The problem occurred when using webforJ addon components as dependencies in other projects - the annotations contained unresolved property placeholders instead of the actual CDN URLs.
